### PR TITLE
add drracket:debug:test-coverage-frame-mixin to doc

### DIFF
--- a/drracket/scribblings/tools/debug.scrbl
+++ b/drracket/scribblings/tools/debug.scrbl
@@ -18,7 +18,7 @@
 
 @defmixin[drracket:debug:profile-tab-mixin
           (drracket:unit:tab<%>)
-          ()]{
+          (drracket:debug:profile-interactions-tab<%>)]{
  Tracks profiling information.
 }
 
@@ -35,12 +35,17 @@
 }
 @defmixin[drracket:debug:test-coverage-interactions-text-mixin
           (drracket:rep:text<%> text:basic<%>)
-          ()]{
+          (drracket:debug:test-coverage-interactions-text<%>)]{
  Tracks test case coverage information.
 }
 @defmixin[drracket:debug:test-coverage-tab-mixin
           (drracket:rep:context<%> drracket:unit:tab<%>)
-          ()]{
+          (drracket:debug:test-coverage-tab<%>)]{
+ Tracks test case coverage information.
+}
+@defmixin[drracket:debug:test-coverage-frame-mixin
+          (drracket:unit:frame<%>)
+          (drracket:debug:test-coverage-frame<%>)]{
  Tracks test case coverage information.
 }
 


### PR DESCRIPTION
Was getting a drracket doc compile error. I think this fixes it. Added a few missing output interfaces as well.