### PR TITLE
Fix button order

### DIFF
--- a/drracket/gui-debugger/debug-tool.rkt
+++ b/drracket/gui-debugger/debug-tool.rkt
@@ -57,7 +57,8 @@
               (alternate-bitmap small-debug-bitmap)
               (parent parent)
               (callback (λ (button) (send frame debug-callback)))))
-       'macro-stepper)
+       'debug-tool
+       #:number 60)
       (drscheme:language:extend-language-interface
        debugger-language<%>
        (lambda (superclass)


### PR DESCRIPTION
Based on old screenshots like https://en.wikipedia.org/wiki/Racket_%28programming_language%29#/media/File:Drracket.png I think the "debug" button is supposed to come after "check syntax". This PR fixes this ordering for typical uses (switching the language to "R5RS" for example seems to mess up the order, but I think it's an unrelated problem).