### PR TITLE
Fix "could not find "Modern" style" error when compiling the documentation

### DIFF
--- a/drracket/scribblings/drracket/interface-essentials.scrbl
+++ b/drracket/scribblings/drracket/interface-essentials.scrbl
@@ -794,7 +794,8 @@ As an example, this is the specification of the @racket["Modern"] style:
             '()))))
    (define name-as-string-datum
      (filter
-      (λ (x) (equal? (hash-ref x 'name) "Modern"))
+      (λ (x) (equal? (hash-ref x 'name)
+                     (string-constant modern-color-scheme)))
       (let loop ([datum datum])
         (cond
           [(list? datum)


### PR DESCRIPTION
The `filter` operates on a list where the style names are translated, but looked for an untranslated name, giving an error when compiling on a system with a French locale, for example ("Moderne" with an "e" instead of "Modern")