### PR TITLE
First attempt to extend check syntax with remove-unused-requires refactoring

### DIFF
--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -409,7 +409,8 @@ in order to make the results be platform independent.
                     syncheck:add-jump-to-definition
                     syncheck:add-id-set 
                     syncheck:color-range
-                    syncheck:add-prefixed-require-reference]
+                    syncheck:add-prefixed-require-reference
+                    syncheck:add-unused-require]
 
 @section{Module Browser}
 

--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -275,6 +275,16 @@ in order to make the results be platform independent.
   or a similar form). The method is passed
   the location of the @racket[require] in the original program.
  }
+
+ @defmethod[(syncheck:add-unused-require
+             [req-src (not/c #f)]
+             [req-pos-left exact-nonnegative-integer?]
+             [req-pos-right exact-nonnegative-integer?])
+            void?]{
+  This method is called for each @racket[require] that Check Syntax
+  determines to be unused. The method is passed the location of the
+  name of the required module in the original program.
+ }
                   
  @defmethod[(syncheck:add-jump-to-definition [source-obj (not/c #f)] 
                                              [start exact-nonnegative-integer?]

--- a/drracket-tool-lib/drracket/check-syntax.rkt
+++ b/drracket-tool-lib/drracket/check-syntax.rkt
@@ -46,6 +46,7 @@
  syncheck:add-mouse-over-status
  syncheck:add-jump-to-definition
  syncheck:add-prefixed-require-reference
+ syncheck:add-unused-require
  syncheck:color-range)
 
 (define (show-content file-or-stx)

--- a/drracket-tool-lib/drracket/private/syncheck/syncheck-intf.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/syncheck-intf.rkt
@@ -17,6 +17,7 @@
     syncheck:add-jump-to-definition
     syncheck:add-definition-target
     syncheck:add-prefixed-require-reference
+    syncheck:add-unused-require
     syncheck:color-range
     
     syncheck:add-rename-menu))

--- a/drracket-tool-lib/drracket/private/syncheck/syncheck-intf.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/syncheck-intf.rkt
@@ -69,6 +69,7 @@
     (define/public (syncheck:add-prefixed-require-reference req-src req-pos-left req-pos-right
                                                             prefix-in-src prefix-in-pos)
       (void))
+    (define/public (syncheck:add-unused-require req-src req-pos-left req-pos-right) (void))
     (super-new)))
 
 (provide syncheck-annotations<%>

--- a/drracket-tool-lib/drracket/private/syncheck/syncheck-local-member-names.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/syncheck-local-member-names.rkt
@@ -16,4 +16,5 @@
   syncheck:add-tail-arrow
   syncheck:add-mouse-over-status
   syncheck:add-jump-to-definition
-  syncheck:add-prefixed-require-reference)
+  syncheck:add-prefixed-require-reference
+  syncheck:add-unused-require)

--- a/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
@@ -773,6 +773,7 @@
               (when (and pos span)
                 (define start (- pos 1))
                 (define fin (+ start span))
+                (send defs-text syncheck:add-unused-require source-editor start fin)
                 (send defs-text syncheck:add-background-color
                       source-editor start fin "firebrick")))
             (color stx unused-require-style-name)))))
@@ -1434,6 +1435,7 @@
     (log syncheck:add-docs-menu _text start-pos end-pos key the-label path definition-tag tag)
     (log syncheck:add-id-set to-be-renamed/poss dup-name?)
     (log syncheck:add-prefixed-require-reference _req-src req-pos-left req-pos-right)
+    (log syncheck:add-unused-require _req-src req-pos-left req-pos-right)
     
     (define/public (get-trace) (reverse trace))
     (define/public (add-to-trace thing) 

--- a/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
@@ -726,8 +726,9 @@
                                module-lang-requires))))
       
       (for ([(phase+mods require-hash) (in-hash phase-to-requires)])
-        (define unused-hash (hash-ref unused/phases phase+mods))
-        (color-unused require-hash unused-hash module-lang-requires))
+        (when (car phase+mods)
+          (define unused-hash (hash-ref unused/phases phase+mods))
+          (color-unused require-hash unused-hash module-lang-requires)))
       
       (annotate-counts connections)
       

--- a/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
@@ -726,6 +726,7 @@
                                module-lang-requires))))
       
       (for ([(phase+mods require-hash) (in-hash phase-to-requires)])
+        ;; don't mark for-label requires as unused until we can properly handle them
         (when (car phase+mods)
           (define unused-hash (hash-ref unused/phases phase+mods))
           (color-unused require-hash unused-hash module-lang-requires)))

--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -767,7 +767,8 @@ If the namespace does not, they are colored the unbound color.
               (for ([req (in-list unused-reqs)])
                 (match-define (list edit start end) req)
                 (define prev-token-end (find-preceding-ws-pos edit start))
-                (send edit delete prev-token-end end))
+                (send edit delete prev-token-end end)
+                (send edit tabify prev-token-end))
               (hash-clear! unused-require-table)
               (end-edit-sequence))
 

--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -602,7 +602,8 @@ If the namespace does not, they are colored the unbound color.
               (set! arrow-records (make-hasheq))
               (set! bindings-table (make-hash))
               (set! cleanup-texts '())
-              (set! definition-targets (make-hash)))
+              (set! definition-targets (make-hash))
+              (set! unused-require-table (make-hash)))
             
             (define/public (syncheck:arrows-visible?)
               (or arrow-records cursor-pos cursor-text cursor-eles cursor-tooltip))

--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -752,6 +752,9 @@ If the namespace does not, they are colored the unbound color.
                    (define-values (ws-start ws-end)
                      (send edit get-token-range (sub1 current-pos)))
                    (loop (send edit classify-position (sub1 ws-start)) ws-start)]
+                  [(and (eq? token-type 'comment)
+                        (char=? (send edit get-character current-pos) #\newline))
+                   (add1 current-pos)]
                   [else current-pos])))
 
             (define/public (remove-unused-requires txt pos)


### PR DESCRIPTION
This pull request adds a new right click menu item that removes all requires which check syntax determines are unused.

It can turn this program:
```
#lang racket
(require cover racket/gui syntax/parse)
```
into this one:
```
#lang racket
(require  racket/gui )
```
Because the tool only knows the locations of the required modules to be removed, the spacing in a resulting require form may contain unnecessary spaces.