### PR TITLE
Move syntax-check arrow colors into color scheme.

### DIFF
--- a/drracket/drracket/HISTORY.txt
+++ b/drracket/drracket/HISTORY.txt
@@ -5,6 +5,8 @@
   . added a font size option to the "insert large letters"
     menu item
 
+  . added color scheme entries for syntax-check arrows
+
 ------------------------------
        Version 6.10
 ------------------------------

--- a/drracket/drracket/info.rkt
+++ b/drracket/drracket/info.rkt
@@ -52,7 +52,11 @@
     (drracket:read-eval-print-loop:value-color ,dark-blue) 
     (drracket:check-syntax:free-variable ,tol-bow-error-color)
     (drracket:check-syntax:set!d ,tol-bow-error-color)
-    (drracket:check-syntax:unused-require ,tol-bow-error-color)))
+    (drracket:check-syntax:unused-require ,tol-bow-error-color)
+    (drracket:syncheck:matching-identifiers ,light-green)
+    (drracket:syncheck:var-arrow ,sea-green)
+    (drracket:syncheck:template-arrow ,dark-plum)
+    (drracket:syncheck:tail-arrow ,dark-red)))
 
 (define tol-wob-constants light-blue)
 (define tol-wob-error light-pink)
@@ -73,7 +77,11 @@
     (drracket:read-eval-print-loop:value-color ,light-blue) 
     (drracket:check-syntax:free-variable ,tol-wob-error)
     (drracket:check-syntax:set!d ,tol-wob-error)
-    (drracket:check-syntax:unused-require ,tol-wob-error)))
+    (drracket:check-syntax:unused-require ,tol-wob-error)
+    (drracket:syncheck:matching-identifiers ,dark-green)
+    (drracket:syncheck:var-arrow ,light-pink)
+    (drracket:syncheck:template-arrow ,burnt-orange)
+    (drracket:syncheck:tail-arrow ,light-green)))
 
 (define framework:color-schemes 
   (list 

--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -181,6 +181,20 @@ If the namespace does not, they are colored the unbound color.
 (color-prefs:add-color-scheme-entry 'drracket:syncheck:matching-identifiers 
                                     "GreenYellow"
                                     "DarkGreen")
+(color-prefs:add-color-scheme-entry 'drracket:syncheck:var-arrow
+                                    "BLUE"
+                                    "LightSteelBlue")
+(color-prefs:add-color-scheme-entry 'drracket:syncheck:template-arrow
+                                    (send the-color-database find-color "purple")
+                                    "orchid")
+(color-prefs:add-color-scheme-entry 'drracket:syncheck:tail-arrow
+                                    "orchid"
+                                    "orchid")
+(let ([framework:basic-canvas-background (color-prefs:lookup-in-color-scheme
+                                          'framework:basic-canvas-background)])
+  (color-prefs:add-color-scheme-entry 'drracket:syncheck:untacked
+                                      framework:basic-canvas-background
+                                      framework:basic-canvas-background))
 
 (define tool@ 
   (unit 
@@ -247,32 +261,36 @@ If the namespace does not, they are colored the unbound color.
 
     (define-struct prefixable-reference (id-text id-start id-end))
     
-    (define (get-tacked-var-brush white-on-black?)
-      (if white-on-black?
-          (send the-brush-list find-or-create-brush "LightSteelBlue" 'solid)
-          (send the-brush-list find-or-create-brush "BLUE" 'solid)))
-    (define (get-var-pen white-on-black?)
-      (if white-on-black?
-          (send the-pen-list find-or-create-pen "LightSteelBlue" 1 'solid)
-          (send the-pen-list find-or-create-pen "BLUE" 1 'solid)))
+    (define (get-tacked-var-brush)
+      (send the-brush-list find-or-create-brush
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:var-arrow)
+            'solid))
+    (define (get-var-pen)
+      (send the-pen-list find-or-create-pen
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:var-arrow)
+            1 'solid))
     
     (define templ-color (send the-color-database find-color "purple"))
-    (define (get-templ-pen white-on-black?)
-      (if white-on-black?
-          (send the-pen-list find-or-create-pen "orchid" 1 'solid)
-          (send the-pen-list find-or-create-pen templ-color 1 'solid)))
-    (define (get-tacked-templ-brush white-on-black?) 
-      (if white-on-black?
-          (send the-brush-list find-or-create-brush "orchid" 'solid)
-          (send the-brush-list find-or-create-brush templ-color 'solid)))
+    (define (get-templ-pen)
+      (send the-pen-list find-or-create-pen
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:template-arrow)
+            1 'solid))
+    (define (get-tacked-templ-brush)
+      (send the-brush-list find-or-create-brush
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:template-arrow)
+            'solid))
     
-    (define (get-tail-pen white-on-black?) 
-      (send the-pen-list find-or-create-pen "orchid" 1 'solid))
-    (define (get-tacked-tail-brush white-on-black?)
-      (send the-brush-list find-or-create-brush "orchid" 'solid))
-    (define (get-untacked-brush white-on-black?)
+    (define (get-tail-pen)
+      (send the-pen-list find-or-create-pen
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:tail-arrow)
+            1 'solid))
+    (define (get-tacked-tail-brush)
+      (send the-brush-list find-or-create-brush
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:tail-arrow)
+            'solid))
+    (define (get-untacked-brush)
       (send the-brush-list find-or-create-brush 
-            (if white-on-black? "black" "white")
+            (color-prefs:lookup-in-color-scheme 'drracket:syncheck:untacked)
             'solid))
         
     (define-local-member-name
@@ -1137,13 +1155,13 @@ If the namespace does not, they are colored the unbound color.
                       (cond
                         [(var-arrow? arrow)
                          (if (var-arrow-actual? arrow)
-                             (begin (send dc set-pen (get-var-pen white-on-black?))
-                                    (send dc set-brush (get-tacked-var-brush white-on-black?)))
-                             (begin (send dc set-pen (get-templ-pen white-on-black?))
-                                    (send dc set-brush (get-tacked-templ-brush white-on-black?))))]
+                             (begin (send dc set-pen (get-var-pen))
+                                    (send dc set-brush (get-tacked-var-brush)))
+                             (begin (send dc set-pen (get-templ-pen))
+                                    (send dc set-brush (get-tacked-templ-brush))))]
                         [(tail-arrow? arrow)
-                         (send dc set-pen (get-tail-pen white-on-black?))
-                         (send dc set-brush (get-tacked-tail-brush white-on-black?))])
+                         (send dc set-pen (get-tail-pen))
+                         (send dc set-brush (get-tacked-tail-brush))])
                       (draw-arrow2 arrow)))
                   (when (and cursor-pos
                              cursor-text)
@@ -1153,16 +1171,16 @@ If the namespace does not, they are colored the unbound color.
                       (for ([ele (in-list arrow-records-at-cursor)])
                         (cond [(var-arrow? ele)
                                (if (var-arrow-actual? ele)
-                                   (begin (send dc set-pen (get-var-pen white-on-black?))
-                                          (send dc set-brush (get-untacked-brush white-on-black?)))
-                                   (begin (send dc set-pen (get-templ-pen white-on-black?))
-                                          (send dc set-brush (get-untacked-brush white-on-black?))))
+                                   (begin (send dc set-pen (get-var-pen))
+                                          (send dc set-brush (get-untacked-brush)))
+                                   (begin (send dc set-pen (get-templ-pen))
+                                          (send dc set-brush (get-untacked-brush))))
                                (draw-arrow2 ele)]
                               [(tail-arrow? ele)
                                (set! tail-arrows (cons ele tail-arrows))])))
                     
-                    (send dc set-pen (get-tail-pen white-on-black?))
-                    (send dc set-brush (get-untacked-brush white-on-black?))
+                    (send dc set-pen (get-tail-pen))
+                    (send dc set-brush (get-untacked-brush))
                     (for-each-tail-arrows draw-arrow2 tail-arrows))
                   (send dc set-brush old-brush)
                   (send dc set-pen old-pen)

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -64,4 +64,4 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.6")
+(define version "1.7")


### PR DESCRIPTION
This allows the color scheme package to configure the color of the arrows.