### PR TITLE
Display tooltips that are too large, and update docs on positions

### DIFF
--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -1052,8 +1052,13 @@ If the namespace does not, they are colored the unbound color.
             ;; If use-key? is #f, it adds `to-add' without a key.
             ;; pre: arrow-records is not #f
             (define/private (add-to-range/key text start pre-end to-add key use-key?)
-              (define end (if (= start pre-end) (+ start 1) pre-end))
-              (when (<= 0 start end (send text last-position))
+              ;; Truncate the end of the tooltip region to the final
+              ;; position in the editor. Too-long tooltips occur due
+              ;; to the indexing difference between syntax objects and
+              ;; editors.
+              (define end (min (if (= start pre-end) (+ start 1) pre-end)
+                               (send text last-position)))
+              (when (<= 0 start end)
                 (define arrow-record (get-arrow-record text))
                 ;; Dropped the check (< _ (vector-length arrow-vector))
                 ;; which had the following comment:

--- a/drracket/scribblings/tools/tools.scrbl
+++ b/drracket/scribblings/tools/tools.scrbl
@@ -760,9 +760,11 @@ are either ignored or are vectors of the shape
 Each vector's content indicates where to show a tooltip. The first three components are
 a syntax object whose @racket[syntax-source] field indicates which file the tooltip goes in,
 the start and end position in the editor where mouseovers will show the tooltip, 
-and the content of the tooltip. If the tooltip content is a procedure, this procedure
-is called by Check Syntax to compute the string used for the tooltip, as Check Syntax
-traverses the syntax objects looking for properties.
+and the content of the tooltip. Note that editor positions count from zero, while syntax
+object positions count from one, so use @racket[sub1] to convert between them. If the
+tooltip content is a procedure, this procedure is called by Check Syntax to compute the
+string used for the tooltip, as Check Syntax traverses the syntax objects looking for
+properties.
 
 For example, here's a macro that shows the span of itself in a tooltip on mouseover:
 @codeblock{
@@ -775,9 +777,9 @@ For example, here's a macro that shows the span of itself in a tooltip on mouseo
       'mouse-over-tooltips
       (vector
        stx
-       (syntax-position stx)
-       (+ (syntax-position stx)
-          (syntax-span stx))
+       (sub1 (syntax-position stx))
+       (sub1 (+ (syntax-position stx)
+             (syntax-span stx)))
        (format "this expression\nspans ~a chars"
                (syntax-span stx))))]))
 


### PR DESCRIPTION
Previously, the example code in the documentation for tooltips did not
work unless there was additional whitespace at the end of the
module. This occurred for two reasons: tooltips outside the valid
range for editor positions were ignored, and tooltips are given in
editor positions, which differ from syntax object positions, so the
tooltip stuck out past the end of the file and was ignored.

This commit does two things to fix this:
 1. Tooltip regions are truncated, rather than ignored, when they
    exceed the file length.
 2. The docs mention the difference in indexing, and the sample code
    contains the necessary sub1 calls.

This solution is backwards-compatible - some non-working programs now
work, but working programs won't change the semantics of tooltip
placement.

Fixes #113.