### PR TITLE
Create dropshadow.css

### DIFF
--- a/drracket/scribblings/drracket/dropshadow.css
+++ b/drracket/scribblings/drracket/dropshadow.css
@@ -1,0 +1,4 @@
+
+.dropshadow {
+    box-shadow: 0px 0px 40px #000;
+}


### PR DESCRIPTION
css style to add drop shadow to images so you can specify a drop shadow to a screenshot without processing the image to add the drop shadow.

Needed to add drop shadow to image in [PR 165](https://github.com/racket/drracket/pull/165)

#lang scribble/manual
--
@(require scribble/core
scribble/html-properties)
 
@(define drop-shadow
(make-style "dropshadow"
(list (make-css-addition "dropshadow.css"))))
 
@title{Example Drop Shadow on image}
 
@centerline{@image[#:scale 0.7 #:style drop-shadow "define.png"]}

