### PR TITLE
Translate a message on the startup screen

### DIFF
--- a/drracket/drracket/private/rep.rkt
+++ b/drracket/drracket/private/rep.rkt
@@ -1791,7 +1791,7 @@ TODO
           (insert/delta this (string-append " [" (string-constant custom) "]") dark-green-delta))
         (when custodian-limit
           (insert/delta this 
-                        "; memory limit: "
+                        (format " ~a " (string-constant memory-limit))
                         welcome-delta)
           (insert/delta this
                         (format "~a MB" (floor (/ custodian-limit 1024 1024)))

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -18,7 +18,7 @@
                "sandbox-lib"
                ("scribble-lib" #:version "1.11")
                ("snip-lib" #:version "1.2")
-               ["string-constants-lib" #:version "1.19"]
+               ["string-constants-lib" #:version "1.25"]
                "typed-racket-lib"
                "wxme-lib"
                ["gui-lib" #:version "1.39"]


### PR DESCRIPTION
The message is "memory limit".  Reuse the limit-memory-limited constant which seems fine
The construction of the message is suboptimal but should be fine for now

Signed-off-by: Alexander Shopov <ash@kambanaria.org>