### PR TITLE
Fix String Constant save-after-switching-tabs Typo

### DIFF
--- a/drracket/drracket/private/main.rkt
+++ b/drracket/drracket/private/main.rkt
@@ -374,7 +374,7 @@
                      editor-panel)
 
      (make-check-box 'drracket:save-files-on-tab-switch?
-                     (string-constant save-after-switching-tabs?)
+                     (string-constant save-after-switching-tabs)
                      editor-panel)
      ))
   

--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -2982,7 +2982,7 @@
                 (string-constant many-files-not-saved-do-the-save?)
                 (for/list ([tab (in-list save-candidates)])
                   (~a "\n" (get-tab-filename tab)))))
-           (string-constant save-after-switching-tabs?)
+           (string-constant save-after-switching-tabs)
            (string-constant save-all-files)
            (string-constant dont-save)
            #f


### PR DESCRIPTION
There are no `?` at the end in racket/string-constants@6cc8c17e0008ded2aa537cffb5ddb9bccfb1494f.