### PR TITLE
scribble: make Scribble PDF button work on 'unix, and simplify for HTML

### DIFF
--- a/drracket/scribble/tools/drracket-buttons.rkt
+++ b/drracket/scribble/tools/drracket-buttons.rkt
@@ -56,16 +56,8 @@
                                                                    'scribble/pdf-render)
                                                                'render-mixin)
                                #:xrefs (list xref)))
-                            (define file-to-open (path-replace-suffix fn suffix)) 
-                            (cond
-                              [html?
-                               (send-url/file file-to-open)]
-                              [else
-                               (if (equal? (system-type) 'windows)
-                                   (send-url/file file-to-open)
-                                   (parameterize ([current-input-port (open-input-string "")])
-                                     (system (format "open \"~a\""
-                                                     (path->string file-to-open)))))])))])
+                            (define file-to-open (path-replace-suffix fn suffix))
+                            (send-url/file (path->string file-to-open))))])
           (send drs-frame execute-callback))]
        [else
         (message-box "Scribble" "Cannot render buffer without filename")]))


### PR DESCRIPTION
Rather than send-url/file on Windows, use start, taking care to supply an
empty first argument (which Windows interprets as a window title).

Use this for HTML too. In fact, xdg-open on GNU/Linux etc., open on macOS,
and start on Windows all work with both files and URLs, so this would work
for http URLs too etc.

Use system* rather than system to avoid quoting problems.