### PR TITLE
drracket/interface-essentials.scrbl: fix out of date number of color schemes

### DIFF
--- a/drracket/scribblings/drracket/interface-essentials.scrbl
+++ b/drracket/scribblings/drracket/interface-essentials.scrbl
@@ -772,7 +772,7 @@ A module browser window contains a square for each
 
 @section[#:tag "color-scheme"]{Color Schemes}
 
-DrRacket comes with three different color schemes, available in the preferences dialog's
+DrRacket comes with a selection of color schemes, available in the preferences dialog's
 @onscreen{color} panel.
 
 You can add your own color schemes to DrRacket, too. The first step is to


### PR DESCRIPTION
Used to be three supplied; now rather more, so reword a little more vaguely.