### PR TITLE
Drop `#f` frames in stack checkpoint test.

### DIFF
--- a/drracket/drracket/private/stack-checkpoint.rkt
+++ b/drracket/drracket/private/stack-checkpoint.rkt
@@ -7,7 +7,7 @@
          racket/match
          framework
          "interface.rkt")
-(module+ test (require rackunit racket/list))
+(module+ test (require (rename-in rackunit [check r:check]) racket/list))
 
 (define oprintf
   (let ([op (current-output-port)])
@@ -146,9 +146,9 @@
 
     (define all-context (map cdr (continuation-mark-set->context cms)))
     (define cut-context (cut-stack-at-checkpoint cms))
-    (check-true (pair? all-context))
+    (check-pred pair? all-context)
     (check-not-equal? all-context cut-context)
-    (check-true (strict-prefix-of? cut-context all-context))))
+    (r:check strict-prefix-of? cut-context all-context)))
 
 (struct viewable-stack (stack-items
                         stack-item->srcloc

--- a/drracket/drracket/private/stack-checkpoint.rkt
+++ b/drracket/drracket/private/stack-checkpoint.rkt
@@ -144,7 +144,7 @@
            (and (equal? (car l1) (car l2))
                 (loop (cdr l1) (cdr l2)))])))
 
-    (define all-context (map cdr (continuation-mark-set->context cms)))
+    (define all-context (map cdr (filter cdr (continuation-mark-set->context cms))))
     (define cut-context (cut-stack-at-checkpoint cms))
     (check-pred pair? all-context)
     (check-not-equal? all-context cut-context)


### PR DESCRIPTION
The `#f` frames are already dropped in `cut-stack-at-checkpoint`, causing
   this test to fail on Racket CS which has some extra `#f` frames at the
   beginning.

   Also, make tests more informative.