### PR TITLE
Repair `drracket:debug:error-display-handler/stacktrace`.

### DIFF
--- a/drracket/drracket/private/debug.rkt
+++ b/drracket/drracket/private/debug.rkt
@@ -336,7 +336,7 @@
               (orig-error-display-handler msg exn)])))))
     debug-error-display-handler)
   
-  ;; error-display-handler/stacktrace : string any (listof srcloc) -> void
+  ;; error-display-handler/stacktrace : string any (or/c #f viewable-stack? (listof srcloc)) -> void
   ;; =User=
   (define (error-display-handler/stacktrace 
            msg exn 
@@ -347,7 +347,8 @@
                                            (send rep get-definitions-text)))])
     (define stack1
       (cond
-        [pre-stack pre-stack]
+        [(viewable-stack? pre-stack) pre-stack]
+        [(list? pre-stack) (srclocs->viewable-stack pre-stack (list ints defs))]
         [(and (exn? exn)
               (continuation-mark-set? (exn-continuation-marks exn)))
          (cms->errortrace-viewable-stack (exn-continuation-marks exn)

--- a/drracket/drracket/private/rep.rkt
+++ b/drracket/drracket/private/rep.rkt
@@ -944,8 +944,8 @@ TODO
                (values a-viewable-stack
                        (cms->builtin-viewable-stack cms interesting-editors
                                                     #:share-cache a-viewable-stack))]
-              [else (values empty-viewable-stack
-                            empty-viewable-stack)])))
+              [else (values (empty-viewable-stack)
+                            (empty-viewable-stack))])))
         (no-user-evaluation-dialog frame exit-code memory-killed? #t)
         (set-insertion-point (last-position))
         (define have-some-stack? (not (and (empty-viewable-stack? vs1)

--- a/drracket/drracket/private/stack-checkpoint.rkt
+++ b/drracket/drracket/private/stack-checkpoint.rkt
@@ -28,7 +28,8 @@
 
 (provide with-stack-checkpoint
          empty-viewable-stack?
-
+         srclocs->viewable-stack
+         viewable-stack?
          ;; provided only for backwards compatibility (exported via debug unit)
          srcloc->edition/pair
          get-editions)


### PR DESCRIPTION
Commit 4b3cff1abfa69 changed (perhaps unintentionally) the contract
for `error-display-handler/stacktrace`. The previous documented
contract expected `(or/c #f list?)` but the new code expects a
`viewable-stack?`.

This changes the two clients in this repository, but there might
be others elsewhere.

`tests/drracket/synchek-test`, which was broken by the change,
passes after this commit.