### PR TITLE
Re-provide build-trace%

### DIFF
--- a/drracket-tool-lib/drracket/check-syntax.rkt
+++ b/drracket-tool-lib/drracket/check-syntax.rkt
@@ -26,7 +26,8 @@
    (parameter/c (or/c #f (is-a?/c syncheck-annotations<%>)))]
   [annotations-mixin 
    (and/c mixin-contract
-          (-> any/c (implementation?/c syncheck-annotations<%>)))]))
+          (-> any/c (implementation?/c syncheck-annotations<%>)))])
+ build-trace%)
 
 (define (has-path-string-source? stx)
   (path-string? (syntax-source stx)))


### PR DESCRIPTION
Although make-traversal is already provided, to use it you also need
build-trace%. Provide officially so people don't need to do a naughty
require of drracket/private/syncheck/traversals.