### PR TITLE
Bump version of setup-racket to 0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.3
+      - uses: Bogdanp/setup-racket@v0.10
         with:
           architecture: x64
           distribution: full


### PR DESCRIPTION
Currently the CS variant fails with `##[error]Unexpected HTTP response: 404`. This PR fixes the problem. See also the discussion at https://github.com/racket/drracket/pull/412 and https://github.com/Bogdanp/setup-racket/pull/12.