### PR TITLE
Fix renaming in DrRacket

### DIFF
--- a/drracket-test/tests/drracket/syncheck-test.rkt
+++ b/drracket-test/tests/drracket/syncheck-test.rkt
@@ -31,7 +31,8 @@
   (define-struct test (line input expected arrows tooltips setup teardown extra-files extra-info?)
     #:transparent)
   (define-struct (dir-test test) () #:transparent)
-  
+
+  ;; When either `new-name` or `output` is `#f`, only test that `old-name` is on the menu
   (define-struct rename-test (line input pos old-name new-name output) #:transparent)
   (define-struct prefix-test (line input pos prefix output) #:transparent)
   
@@ -1547,6 +1548,24 @@
        "  y`1\n"
        "  `2)\n"))
 
+     (build-rename-test
+      (string-append
+       "#lang racket\n"
+       "(require racket/list)\n")
+      14
+      "require"
+      #f
+      #f)
+
+     (build-rename-test
+      (string-append
+       "#lang racket\n"
+       "(require racket/list)\n")
+      20
+      "require"
+      #f
+      #f)
+
      (build-test
       #:extra-files
       (hash "define-suffix.rkt"
@@ -1766,7 +1785,7 @@
                           (map (λ (x) (and (is-a? x labelled-menu-item<%>) (send x get-label)))
                                (send menu get-items)))
                  #f]))))
-         (when menu-item
+         (when (and menu-item (rename-test-new-name test) (rename-test-output test))
            (queue-callback (λ () (send menu-item command (make-object control-event% 'menu))))
            (wait-for-new-frame drs)
            (for ([x (in-string (rename-test-new-name test))])

--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -948,7 +948,7 @@ If the namespace does not, they are colored the unbound color.
               ;; NOTE: for consistency, try to match how selection currently works
               ;; in DrRacket, even though it is potentially buggy. See issue #414.
               ;;
-              ;; Find an identifier in both binding and bound occurrences
+              ;; Find an identifier in either binding and bound occurrences
               ;; of binding-var-arrows that overlaps the selection
               ;; {start-sel, ..., end-sel}
               ;;


### PR DESCRIPTION
Renaming in DrRacket is currently broken in two ways.

1. Consider the program:

       #lang racket
       (require racket/list)

   Right clicking `require` will offer users to rename the `racket`
   identifier which doesn't make much sense. Users right click `require`
   because they want to rename that particular identifier, not others.

<s>
2. To continue from the above example, renaming `racket` to
   `racket/base` will cause all identifiers imported from `racket` to be
   renamed to `racket/base`. That is, it would result in:

       #lang racket/base
       (require/base racket/list)

   This bug will become even more annoying after racket/racket#3391
   is merged, since renaming any defined identifier will cause
   `all-defined-out` to be renamed as well.
</s>

This PR fixes both issues. That is, renaming at a position will pick an
identifier from that position, <s>and renaming an identifier will only
cause identifiers that are textually equivalent to that identifier
to be renamed.</s>