### PR TITLE
doc: module-lang-require -> module-lang

### DIFF
--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -255,7 +255,7 @@ in order to make the results be platform independent.
                                               [end-py (real-in 0 1)]
                                               [actual? boolean?]
                                               [phase-level (or/c exact-nonnegative-integer? #f)]
-                                              [require-arrow (or/c boolean? 'module-lang-require)]
+                                              [require-arrow (or/c boolean? 'module-lang)]
                                               [name-dup? (-> string? boolean?)])
             void?]{
    Called to indicate that there should be an arrow between the locations described by the first 
@@ -271,7 +271,7 @@ in order to make the results be platform independent.
    The @racket[require-arrow] argument indicates if this arrow points from
    an imported identifier to its corresponding @racket[require]. Any true value means
    that it points to an import via @racket[require]; @racket[#t] means it was a normal
-   @racket[require] and @racket['module-lang-require] means it comes from the implicit require
+   @racket[require] and @racket['module-lang] means it comes from the implicit require
    that a module language provides.
    
    The @racket[name-dup?] predicate returns @racket[#t]
@@ -280,7 +280,7 @@ in order to make the results be platform independent.
    the time the program was expanded).
 
    @history[#:changed "1.1" @list{Changed @racket[require-arrow] to sometimes
-               be @racket['module-lang-require].}]
+               be @racket['module-lang].}]
    
  }
  @defmethod[(syncheck:add-tail-arrow [from-source-obj (not/c #f)]


### PR DESCRIPTION
The symbol has always been module-lang instead of module-lang-require.
It's simply documented incorrectly.