### PR TITLE
Outline for syncheck:add-arrow/name-dup/pxpy/renamable

### DIFF
--- a/drracket-test/tests/drracket/syncheck-test.rkt
+++ b/drracket-test/tests/drracket/syncheck-test.rkt
@@ -1548,24 +1548,6 @@
        "  y`1\n"
        "  `2)\n"))
 
-     (build-rename-test
-      (string-append
-       "#lang racket\n"
-       "(require racket/list)\n")
-      14
-      "require"
-      #f
-      #f)
-
-     (build-rename-test
-      (string-append
-       "#lang racket\n"
-       "(require racket/list)\n")
-      20
-      "require"
-      #f
-      #f)
-
      (build-test
       #:extra-files
       (hash "define-suffix.rkt"

--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -41,8 +41,7 @@ that are exposed via Racket APIs to be used with other editors.
  the vector are the arguments passed to the method.
  (Note that this procedure does not account for the callback
  procedures present in
- @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy]
- and @method[syncheck-annotations<%> syncheck:add-id-set].)
+ @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy/renamable].)
 
  The @racket[file-or-stx] argument gives the input program
  and @racket[fully-expanded?] indicates if the
@@ -207,7 +206,7 @@ in order to make the results be platform independent.
             void?]{This method is no longer called by Check Syntax. It is here
                    for backwards compatibility only. The information it provided
                    must now be synthesized from the information supplied to
-                   @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy].}
+                   @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy/renamable].}
            
  @defmethod[(syncheck:add-arrow [start-source-obj (not/c #f)]
                                 [start-left exact-nonnegative-integer?]
@@ -219,7 +218,7 @@ in order to make the results be platform independent.
                                 [phase-level (or/c exact-nonnegative-integer? #f)])
             void?]{
     This function is not called directly anymore by Check Syntax. Instead
-    @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy] is.
+    @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy/renamable] is.
     
     This method is invoked by the default implementation of 
     @racket[_syncheck:add-arrow/name-dup] in 
@@ -237,11 +236,11 @@ in order to make the results be platform independent.
                                          [name-dup? (-> string? boolean?)])
             void?]{
     This function is not called directly anymore by Check Syntax. Instead
-    @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy] is.
+    @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy/renamable] is.
 
-    The default implementation of @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy]
-    discards the @racket[_start-px] @racket[_start-py] @racket[_end-px] @racket[_end-py]
-    arguments and calls this method.
+    This method is invoked by the default implementation of
+    @racket[_syncheck:add-arrow/name-dup/pxpy] in
+    @racket[annotations-mixin].
  }
  @defmethod[(syncheck:add-arrow/name-dup/pxpy [start-source-obj (not/c #f)]
                                               [start-left exact-nonnegative-integer?]
@@ -257,6 +256,29 @@ in order to make the results be platform independent.
                                               [phase-level (or/c exact-nonnegative-integer? #f)]
                                               [require-arrow (or/c boolean? 'module-lang-require)]
                                               [name-dup? (-> string? boolean?)])
+            void?]{
+    This function is not called directly anymore by Check Syntax. Instead
+    @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy/renamable] is.
+
+    This method is invoked by the default implementation of
+    @racket[_syncheck:add-arrow/name-dup/pxpy/renamable] in
+    @racket[annotations-mixin].
+ }
+ @defmethod[(syncheck:add-arrow/name-dup/pxpy/renamable
+             [start-source-obj (not/c #f)]
+             [start-left exact-nonnegative-integer?]
+             [start-right exact-nonnegative-integer?]
+             [start-px (real-in 0 1)]
+             [start-py (real-in 0 1)]
+             [end-source-obj (not/c #f)]
+             [end-left exact-nonnegative-integer?]
+             [end-right exact-nonnegative-integer?]
+             [end-px (real-in 0 1)]
+             [end-py (real-in 0 1)]
+             [actual? boolean?]
+             [phase-level (or/c exact-nonnegative-integer? #f)]
+             [require-arrow (or/c boolean? 'module-lang)]
+             [name-dup? (-> string? boolean?)])
             void?]{
    Called to indicate that there should be an arrow between the locations described by the first 
    ten arguments. The @racket[start-px] and @racket[start-py] indicate how far along the diagonal
@@ -392,7 +414,10 @@ in order to make the results be platform independent.
             @item{the @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy]
                       method drops the @racket[_from-px], @racket[_from-py], @racket[_to-px],
                       and @racket[_to-py] arguments and calls
-                      @method[syncheck-annotations<%> syncheck:add-arrow/name-dup]; and}
+                      @method[syncheck-annotations<%> syncheck:add-arrow/name-dup]}
+            @item{the @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy/renamable]
+                      method drops the @racket[_renamable?] argument and calls
+                      @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy]; and}
             @item{all of the other methods ignore their arguments and return @racket[(void)].}]
     
   Here is an example showing how use this library to extract all
@@ -409,10 +434,10 @@ in order to make the results be platform independent.
                    (super-new)
                    (define/override (syncheck:find-source-object stx)
                      stx)
-                   (define/override (syncheck:add-arrow/name-dup/pxpy
+                   (define/override (syncheck:add-arrow/name-dup/pxpy/renamable
                                      start-source-obj start-left start-right start-px start-py
                                      end-source-obj end-left end-right end-px end-py
-                                     actual? phase-level require-arrow? name-dup?)
+                                     actual? phase-level require-arrow? name-dup? renamable?)
                      (set! arrows
                            (cons (list start-source-obj end-source-obj)
                                  arrows)))
@@ -456,6 +481,7 @@ in order to make the results be platform independent.
                     syncheck:add-arrow
                     syncheck:add-arrow/name-dup
                     syncheck:add-arrow/name-dup/pxpy
+                    syncheck:add-arrow/name-dup/pxpy/renamable
                     syncheck:add-tail-arrow
                     syncheck:add-mouse-over-status
                     syncheck:add-jump-to-definition

--- a/drracket-tool-lib/drracket/check-syntax.rkt
+++ b/drracket-tool-lib/drracket/check-syntax.rkt
@@ -46,6 +46,7 @@
  syncheck:add-arrow
  syncheck:add-arrow/name-dup
  syncheck:add-arrow/name-dup/pxpy
+ syncheck:add-arrow/name-dup/pxpy/renamable
  syncheck:add-tail-arrow
  syncheck:add-mouse-over-status
  syncheck:add-jump-to-definition

--- a/drracket-tool-lib/drracket/private/syncheck/syncheck-intf.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/syncheck-intf.rkt
@@ -13,6 +13,7 @@
     syncheck:add-arrow
     syncheck:add-arrow/name-dup
     syncheck:add-arrow/name-dup/pxpy
+    syncheck:add-arrow/name-dup/pxpy/renamable
     syncheck:add-tail-arrow
     syncheck:add-mouse-over-status
     syncheck:add-jump-to-definition
@@ -63,6 +64,20 @@
       (syncheck:add-arrow/name-dup start-text start-pos-left start-pos-right
                                    end-text end-pos-left end-pos-right
                                    actual? level require-arrow? name-dup?))
+    (define/public (syncheck:add-arrow/name-dup/pxpy/renamable
+                    start-text
+                    start-pos-left start-pos-right
+                    start-px start-py
+                    end-text
+                    end-pos-left end-pos-right
+                    end-px end-py
+                    actual? level require-arrow? name-dup? renamable?)
+      (syncheck:add-arrow/name-dup/pxpy
+       start-text start-pos-left start-pos-right
+       start-px start-py
+       end-text end-pos-left end-pos-right
+       end-px end-py
+       actual? level require-arrow? name-dup?))
     (define/public (syncheck:add-tail-arrow from-text from-pos to-text to-pos) (void))
     (define/public (syncheck:add-mouse-over-status text pos-left pos-right str) (void))
     

--- a/drracket-tool-lib/drracket/private/syncheck/syncheck-local-member-names.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/syncheck-local-member-names.rkt
@@ -13,6 +13,7 @@
   syncheck:add-arrow
   syncheck:add-arrow/name-dup
   syncheck:add-arrow/name-dup/pxpy
+  syncheck:add-arrow/name-dup/pxpy/renamable
   syncheck:add-rename-menu
   syncheck:add-tail-arrow
   syncheck:add-mouse-over-status

--- a/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
@@ -1144,10 +1144,14 @@
            ans)
          (when (and (<= from-pos-left from-pos-right)
                     (<= to-pos-left to-pos-right))
-           (send defs-text syncheck:add-arrow/name-dup/pxpy
+           (define renamable?
+             (not (or require-arrow?
+                      (syntax-property to 'inhibit-renaming?)
+                      (syntax-property from 'inhibit-renaming?))))
+           (send defs-text syncheck:add-arrow/name-dup/pxpy/renamable
                  from-source from-pos-left from-pos-right from-dx from-dy
                  to-source to-pos-left to-pos-right to-dx to-dy
-                 actual? level require-arrow? name-dup?))]
+                 actual? level require-arrow? name-dup? renamable?))]
         [else
          (unless (hash-ref connections connections-key #f)
            (hash-set! connections connections-key #t)

--- a/drracket/drracket/private/syncheck/online-comp.rkt
+++ b/drracket/drracket/private/syncheck/online-comp.rkt
@@ -61,19 +61,21 @@
     (define-values (remote-chan local-chan) (place-channel))
     (define table (make-hash))
     (create-rename-answerer-thread orig-cust local-chan table)
-    (define/override (syncheck:add-arrow/name-dup/pxpy _start-text
-                                                       start-pos-left start-pos-right
-                                                       start-px start-py
-                                                       _end-text
-                                                       end-pos-left end-pos-right
-                                                       end-px end-py
-                                                       actual? level require-arrow? name-dup?)
+    (define/override (syncheck:add-arrow/name-dup/pxpy/renamable
+                      _start-text
+                      start-pos-left start-pos-right
+                      start-px start-py
+                      _end-text
+                      end-pos-left end-pos-right
+                      end-px end-py
+                      actual? level require-arrow? name-dup?
+                      renamable?)
       (define id (hash-count table))
       (hash-set! table id name-dup?)
-      (add-to-trace (vector 'syncheck:add-arrow/name-dup/pxpy
+      (add-to-trace (vector 'syncheck:add-arrow/name-dup/pxpy/renamable
                             start-pos-left start-pos-right start-px start-py
                             end-pos-left end-pos-right end-px end-py
-                            actual? level require-arrow? remote-chan id)))
+                            actual? level require-arrow? remote-chan id renamable?)))
     
     (define/override (syncheck:add-id-set to-be-renamed/poss dup-name?)
       (define id (hash-count table))


### PR DESCRIPTION
@rfindler here's an implementation of what I discussed earlier in #415.

> There are two problems at hand: (1) how can language + macro indicate when it's safe (or unsafe) to rename an identifier? (2) how can Check Syntax provide these information to clients (e.g., DrRacket, Racket Mode) in a backward-compatible manner?
>
> For (2), Racket Mode currently uses `syncheck:add-arrow/name-dup/pxpy` to decide whether or not a variable is rename-able. For example, Racket Mode deliberately restricts renaming to local variables (`require-arrow` in `syncheck:add-arrow/name-dup/pxpy` is `#f`). This suggests that the fix is to extend `syncheck:add-arrow/name-dup/pxpy` to `syncheck:add-arrow/name-dup/pxpy/renamable`. The additional argument `renamable?` would indicate if renaming either end should affect the other end. When `require-arrow` is not `#f`, `renamable?` will be `#f`.
>
> Racket Mode would implement both `syncheck:add-arrow/name-dup/pxpy` and `syncheck:add-arrow/name-dup/pxpy/renamable` to support both old and new versions of DrRacket. At runtime, it can first check if `syncheck-annotations<%>` has a method `syncheck:add-arrow/name-dup/pxpy/renamable`, and if it does, `syncheck:add-arrow/name-dup/pxpy` would be disabled. When `syncheck:add-arrow/name-dup/pxpy/renamable` is not in the interface, `syncheck:add-arrow/name-dup/pxpy/renamable` would simply be unused.
>
> For (1), since currently there's no restriction, it seems to me that to make it backward compatible, it should be an opt-out mechanism. That is, all local connections would make `renamable?` `#t` by default, but a syntax property `inhibit-rename?` setting to `#t` of identifiers in either `disappeared-binding` or `disappeared-use` would make `renamable?` `#f`.

The PR is only for discussion. At the very least it still needs tests and documentation. Not ready to be merged.