### PR TITLE
add relative path support to make-traversals

### DIFF
--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -41,8 +41,7 @@ that are exposed via Racket APIs to be used with other editors.
  the vector are the arguments passed to the method.
  (Note that this procedure does not account for the callback
  procedures present in
- @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy]
- and @method[syncheck-annotations<%> syncheck:add-id-set].)
+ @method[syncheck-annotations<%> syncheck:add-arrow/name-dup/pxpy].)
 
  The @racket[file-or-stx] argument gives the input program
  and @racket[fully-expanded?] indicates if the
@@ -83,7 +82,7 @@ in order to make the results be platform independent.
 }
 
 @defproc[(make-traversal [namespace namespace?]
-                         [path (or/c #f path-string?)])
+                         [path (or/c #f (and/c path-string? complete-path?))])
          (values (->* (syntax?)
                       ((-> any/c void?))
                       void?)

--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -82,7 +82,7 @@ in order to make the results be platform independent.
 }
 
 @defproc[(make-traversal [namespace namespace?]
-                         [path (or/c #f (and/c path-string? complete-path?))])
+                         [path (or/c #f path-string?)])
          (values (->* (syntax?)
                       ((-> any/c void?))
                       void?)
@@ -104,6 +104,10 @@ in order to make the results be platform independent.
   methods are invoked in the corresponding object (if any), to indicate
   what has been found in the syntax object. These methods will only be called
   if the syntax objects have source locations.
+
+  The @racket[path] argument indicates a directory whose traversal should operate on.
+  When @racket[path] is @racket[#f], it defaults to @racket[(current-directory)].
+  Otherwise, the path is simplified via @racket[simple-form-path] before it's used.
 }
 
 @defparam[current-annotations ca (or/c #f (is-a?/c syncheck-annotations<%>))]{

--- a/drracket-tool-lib/drracket/check-syntax.rkt
+++ b/drracket-tool-lib/drracket/check-syntax.rkt
@@ -65,13 +65,15 @@
       [(syntax? file-or-stx)
        (syntax-source file-or-stx)]))
   (define o (new build-trace% [src src]))
+  (define user-dir (path-only (simple-form-path src)))
   
   (parameterize ([current-annotations o])
     (define-values (expanded-expression expansion-completed) 
-      (make-traversal ns (path-only src)))
+      (make-traversal ns user-dir))
     (cond
       [(path-string? file-or-stx)
-       (parameterize ([current-namespace ns])
+       (parameterize ([current-namespace ns]
+                      [current-load-relative-directory user-dir])
          (expanded-expression
           (expand
            (call-with-input-file file-or-stx
@@ -81,7 +83,8 @@
                 (λ ()
                   (read-syntax file-or-stx port))))))))]
       [else 
-       (parameterize ([current-namespace ns])
+       (parameterize ([current-namespace ns]
+                      [current-load-relative-directory user-dir])
          (expanded-expression
           (if expand?
               (expand file-or-stx)

--- a/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
+++ b/drracket-tool-lib/drracket/private/syncheck/traversals.rkt
@@ -13,7 +13,7 @@
          racket/list
          racket/contract
          racket/pretty
-         racket/bool
+         racket/path
          racket/dict
          syntax/id-table
          scribble/manual-struct
@@ -43,6 +43,7 @@
          [tl-module-lang-requires (make-hash)]
          [tl-phase-to-requires (make-hash)]
          [tl-sub-identifier-binding-directives (make-hash)]
+         [user-directory (and user-directory (simple-form-path user-directory))]
          [expanded-expression
           (λ (sexp [ignored void])
             (parameterize ([current-directory (or user-directory (current-directory))]

--- a/drracket-tool-test/tests/check-syntax/syncheck-direct.rkt
+++ b/drracket-tool-test/tests/check-syntax/syncheck-direct.rkt
@@ -495,7 +495,10 @@
 ;; make sure that `make-traversal` is called with
 ;; the containing directory by `show-content`
 (let ()
-  (define tmp-dir (make-temporary-file "test-from-syncheck-direct-rkt~a" 'directory))
+  (define root-dir (make-temporary-file "test-from-syncheck-direct-rkt~a" 'directory))
+  (parameterize ([current-directory root-dir])
+    (make-directory "test"))
+  (define tmp-dir (build-path root-dir "test"))
   (define src (build-path tmp-dir "prefix.rkt"))
   (call-with-output-file src
     (λ (port)
@@ -511,6 +514,11 @@
   (define content
     (parameterize ([current-directory tmp-dir])
       (show-content src)))
+
+  (check-not-exn
+   (λ ()
+     (parameterize ([current-directory root-dir])
+       (show-content "test/prefix.rkt"))))
 
   (define paths
     (let loop ([content content])


### PR DESCRIPTION
The current requirement of path in make-traversal is that it is
either #f or a path-string? However, because we parameterize
current-load-relative-directory to be this path, providing
any non complete-path? will result in a contract error.
This PR thus strengthens the requirement so that the provided path
must be complete-path?

The PR also fixes the show-content procedure so that
it satisfies the contract. Note that we need additional
parameterization of current-load-relative-directory so that
macro expansion can work correctly on relative path source like:

```
;; main.rkt
(require drracket/check-syntax)
(show-content "test/a.rkt")

;; test/a.rkt
(require "b.rkt")

;; test/b.rkt
1
```

Also cleanup description about `add-id-set`, since the method is no longer called.