### PR TITLE
CI: use automatic server numbering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
              sudo raco pkg config --set catalogs `cat catalog-config.txt`
              sudo raco pkg update -i --auto --no-setup drracket/ drracket-test/ drracket-tool/ drracket-tool-test/ drracket-tool-lib/ drracket-tool-doc/ drracket-plugin-lib/
       - run: sudo raco setup --check-pkg-deps drracket tests/drracket
-      - run: xvfb-run raco test -e -l tests/drracket/module-lang-test
-      - run: xvfb-run raco test -e -l tests/drracket/syncheck-test
+      - run: xvfb-run -a raco test -e -l tests/drracket/module-lang-test
+      - run: xvfb-run -a raco test -e -l tests/drracket/syncheck-test


### PR DESCRIPTION
Without `-a`, multiple runs of `xvfb-run` will use the same server number. If the first `xvfb-run` has not freed the resource yet by the time the second `xvfb-run` is invoked, a conflict will occur, causing an error.

With `-a`, the second `xvfb-run` will automatically pick a different server number, thus avoiding the conflict.

CC: @samth