### PR TITLE
Unbreak syncheck-drracket-button

### DIFF
--- a/drracket/drracket/syncheck-drracket-button.rkt
+++ b/drracket/drracket/syncheck-drracket-button.rkt
@@ -6,10 +6,7 @@
          (for-syntax racket/base images/icons/tool images/icons/style))
 (provide syncheck-drracket-button
          syncheck-bitmap
-         syncheck-small-bitmap
-         syncheck:button-callback)
-
-(define-local-member-name syncheck:button-callback)
+         syncheck-small-bitmap)
 
 (define syncheck-bitmap
   (compiled-bitmap (check-syntax-icon #:height (toolbar-icon-height))))


### PR DESCRIPTION
syncheck-drracket-button tried to call syncheck:button-callback via a
local member name - but this is documented, and part of the interface.

Note that the situation here is different from the stepper button, where a private member name makes more sense.