### PR TITLE
backtrace: fix empty backtrace on subsequent activation

### DIFF
--- a/drracket/drracket/private/debug.rkt
+++ b/drracket/drracket/private/debug.rkt
@@ -542,10 +542,9 @@
        (send note set-stacks viewable-stack1 viewable-stack2)
        (send note set-callback
              (λ (snp)
-               (show-backtrace-window/viewable-stacks
-                msg
-                (copy-viewable-stack viewable-stack1)
-                (copy-viewable-stack viewable-stack2))))
+               (show-backtrace-window/viewable-stacks msg
+                                                      viewable-stack1
+                                                      viewable-stack2)))
        note]
       [else #f]))
 
@@ -783,7 +782,9 @@
      (dis+edition->viewable-stack dis1 editions1 (list defs ints))
      (dis+edition->viewable-stack dis2 editions2 (list defs ints))))
 
-  (define (show-backtrace-window/viewable-stacks error-text viewable-stack1 viewable-stack2)
+  (define (show-backtrace-window/viewable-stacks error-text orig-viewable-stack1 orig-viewable-stack2)
+    (define viewable-stack1 (copy-viewable-stack orig-viewable-stack1))
+    (define viewable-stack2 (copy-viewable-stack orig-viewable-stack2))
     (reset-backtrace-window)
     (define both-non-empty?
       (and (not (empty-viewable-stack? viewable-stack1))

--- a/drracket/drracket/private/debug.rkt
+++ b/drracket/drracket/private/debug.rkt
@@ -542,9 +542,10 @@
        (send note set-stacks viewable-stack1 viewable-stack2)
        (send note set-callback
              (λ (snp)
-               (show-backtrace-window/viewable-stacks msg
-                                                      viewable-stack1
-                                                      viewable-stack2)))
+               (show-backtrace-window/viewable-stacks
+                msg
+                (copy-viewable-stack viewable-stack1)
+                (copy-viewable-stack viewable-stack2))))
        note]
       [else #f]))
 

--- a/drracket/drracket/private/stack-checkpoint.rkt
+++ b/drracket/drracket/private/stack-checkpoint.rkt
@@ -33,7 +33,8 @@
          ;; provided only for backwards compatibility (exported via debug unit)
          srcloc->edition/pair
          get-editions
-         errortrace-stack-item->srcloc)
+         errortrace-stack-item->srcloc
+         copy-viewable-stack)
 
 (provide
  (contract-out
@@ -356,6 +357,9 @@
      (and (srcloc? srcloc)
           srcloc)]
     [else #f]))
+
+(define (copy-viewable-stack s)
+  (struct-copy viewable-stack s))
 
 (define (viewable-stack-get-next-items! a-viewable-stack)
   (match-define (viewable-stack stack-items stack-item->srcloc interesting-editor-editions port-name-matches-cache stack-next-items)


### PR DESCRIPTION
Backtrace display mutates viewable stacks. Therefore, we should copy
them first so that subsequent activations still produce correct result.

Fixes #461