### PR TITLE
Have note% implement srcloc-special<%>.

### DIFF
--- a/drracket/drracket/private/eval.rkt
+++ b/drracket/drracket/private/eval.rkt
@@ -189,6 +189,8 @@
             '(lib "planet/terse-info.rkt")
             '(lib "errortrace/errortrace-key.rkt")
             '(lib "simple-tree-text-markup/data.rkt")
+            ; srclocs-special<%>
+            '(lib "simple-tree-text-markup/port.rkt")
             ;; preserve the invariant that:
             ;;   if a module is shared, so 
             ;;   are all of its submodules

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -40,7 +40,8 @@
                "pict-snip-lib"
                "option-contract-lib"
                "syntax-color-lib"
-               "quickscript"))
+               "quickscript"
+               "simple-tree-text-markup-lib"))
 
 (define build-deps '("mzscheme-doc"
                      "net-doc"


### PR DESCRIPTION
This way, users of simple-tree-text-markup/port can generate links to
srclocs represented by the note% snips.

This goes back to a discussion @rfindler and I have had. Should be viewed as a first draft.