### PR TITLE
Add an option to directly send the URL without trampolines

### DIFF
--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -18,7 +18,7 @@
                "sandbox-lib"
                ("scribble-lib" #:version "1.11")
                ("snip-lib" #:version "1.2")
-               ["string-constants-lib" #:version "1.38"]
+               ["string-constants-lib" #:version "1.39"]
                "typed-racket-lib"
                "wxme-lib"
                ["gui-lib" #:version "1.64"]
@@ -30,7 +30,7 @@
                ["typed-racket-more" #:version "1.12"]
                "trace"
                ["macro-debugger" #:version "1.1"]
-               "net-lib"
+               ["net-lib" #:version "1.1"]
                "tex-table"
                "htdp-lib"
                ("drracket-plugin-lib" #:version "1.1")


### PR DESCRIPTION
This PR adds an option in the browser preference to send URLs directly without going through trampolines. Comments welcome!

- [x] Draw the label of the checkbox from `string-constants`
- [ ] docs
- [x] Code cleanup
