### PR TITLE
New file menu item - Reopen Closed Tab

### DIFF
--- a/drracket/drracket/HISTORY.txt
+++ b/drracket/drracket/HISTORY.txt
@@ -1,4 +1,13 @@
 ------------------------------
+       Version 8.5
+------------------------------
+
+   . added new file menu item 'Reopen Closed Tab' to open previously
+     closed tabs.
+   . Removed keyboard shortcut for 'Spell Check test' in edit menu due  
+     to conflict with  'Reopen Closed Tab'.
+
+------------------------------
        Version 8.4
 ------------------------------
 

--- a/drracket/drracket/private/main.rkt
+++ b/drracket/drracket/private/main.rkt
@@ -617,6 +617,41 @@
   
   (preferences:set-default 'drracket:show-killed-dialog #t boolean?)
   
+  (preferences:set-default 
+    'drracket:recently-closed-tabs 
+    null 
+    (λ (x) (and (list? x) 
+                (andmap
+                (λ (x) 
+                  (and (list? x)
+                        (= 3 (length x))
+                        (path? (car x))
+                        (number? (cadr x))
+                        (number? (caddr x))))
+                x))))
+
+  (preferences:set-un/marshall 
+    'drracket:recently-closed-tabs
+    (λ (l) (map (λ (ele) (cons (path->bytes (car ele)) (cdr ele))) l))
+    (λ (l) 
+      (let/ec k
+        (unless (list? l)
+          (k '()))
+        (map (λ (x)
+                (unless (and (list? x)
+                            (= 3 (length x))
+                            (bytes? (car x))
+                            (number? (cadr x))
+                            (number? (caddr x)))
+                  (k '()))
+                (cons (bytes->path (car x)) (cdr x)))
+              l))))
+  
+  (preferences:set-default 'drracket:recently-closed-tabs-max-count 
+                           50 
+                           (λ (x) (and (number? x)
+                                       (x . > . 0) 
+                                       (integer? x))))
   
   (drr:set-default 'drracket:large-letters-font #f
                    (or/c #f

--- a/drracket/drracket/private/main.rkt
+++ b/drracket/drracket/private/main.rkt
@@ -648,7 +648,7 @@
               l))))
   
   (preferences:set-default 'drracket:recently-closed-tabs-max-count 
-                           50 
+                           1000 
                            (λ (x) (and (number? x)
                                        (x . > . 0) 
                                        (integer? x))))

--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -3075,7 +3075,7 @@
       ;; create-new-tab : -> void
       ;; creates a new tab and updates the GUI for that new tab
       (define/public create-new-tab
-        (lambda ([filename #f] [start-pos 0] [end-pos 'same])
+        (lambda ([filename #f] #:start-pos [start-pos 0] #:end-pos [end-pos 'same])
           (let* ([defs (new (drracket:get/extend:get-definitions-text))]
                  [tab-count (length tabs)]
                  [new-tab (new (drracket:get/extend:get-tab)
@@ -3267,8 +3267,8 @@
            #t]
           [else #f]))
       
-      (define/public (open-in-new-tab filename [start-pos 0] [end-pos 0])
-        (create-new-tab filename start-pos end-pos))
+      (define/public (open-in-new-tab filename #:start-pos [start-pos 0] #:end-pos [end-pos 'same])
+        (create-new-tab filename #:start-pos start-pos #:end-pos end-pos))
       
       ;; reopen-closed-tab : -> void
       ;; Opens previously closed tabs. If no tabs were closed in current session, files from 
@@ -3281,12 +3281,14 @@
               (define filename (first file))
               (and (file-exists? filename)
                    (set! closed-tabs (cdr closed-tabs))
-                   filename)))
+                   file)))
           (when file-to-open
-            (let ((tab (find-matching-tab file-to-open)))
+            (let ([tab (find-matching-tab (car file-to-open))]
+                  [start-pos (cadr file-to-open)]
+                  [end-pos (caddr file-to-open)])
               (if tab
                 (change-to-tab tab)
-                (open-in-new-tab file-to-open))))
+                (open-in-new-tab (car file-to-open) #:start-pos start-pos #:end-pos end-pos))))
           (preferences:set 'drracket:recently-closed-tabs closed-tabs)
           #f))
 

--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -3268,6 +3268,21 @@
       (define/public (open-in-new-tab filename)
         (create-new-tab filename))
       
+      ;; reopen-closed-tab : -> void
+      ;; opens previously closed tab if the file still exists
+      (define/public reopen-closed-tab
+        (lambda ()
+          ; Get the list of recently opened files
+          (define recently-opened-files (preferences:get 'framework:recently-opened-files/pos))
+          (define file-to-open
+            (for/or ([file (in-list recently-opened-files)])
+              (define filename (first file))
+              (and (not (find-matching-tab filename))
+                   (file-exists? filename)
+                   filename)))
+          (open-in-new-tab file-to-open)
+          #f))
+
       (define/public (get-tab-count) (length tabs))
       (define/public (change-to-nth-tab n)
         (unless (< n (length tabs))
@@ -3932,6 +3947,13 @@
                           (let-values ([(base name dir?) (split-path editing-path)])
                             base))))
                   (when pth (handler:edit-file pth)))])
+          (new menu:can-restore-menu-item%
+            (label (string-constant reopen-closed-tab))
+            (shortcut #\*)
+            (parent file-menu)
+            (callback
+            (λ (x y)
+              (reopen-closed-tab))))
           (super file-menu:between-open-and-revert file-menu)
           (make-object separator-menu-item% file-menu))]
       (define close-tab-menu-item #f)

--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -3075,7 +3075,7 @@
       ;; create-new-tab : -> void
       ;; creates a new tab and updates the GUI for that new tab
       (define/public create-new-tab
-        (lambda ([filename #f])
+        (lambda ([filename #f] [start-pos 0] [end-pos 'same])
           (let* ([defs (new (drracket:get/extend:get-definitions-text))]
                  [tab-count (length tabs)]
                  [new-tab (new (drracket:get/extend:get-tab)
@@ -3086,6 +3086,7 @@
                                (ints-shown? (not filename)))]
                  [ints (make-object (drracket:get/extend:get-interactions-text) new-tab)])
             (send new-tab set-ints ints)
+            (send (send new-tab get-defs) set-position start-pos end-pos)
             (set! tabs (append tabs (list new-tab)))
             (send tabs-panel append 
                   (gui-utils:trim-string
@@ -3266,8 +3267,8 @@
            #t]
           [else #f]))
       
-      (define/public (open-in-new-tab filename)
-        (create-new-tab filename))
+      (define/public (open-in-new-tab filename [start-pos 0] [end-pos 0])
+        (create-new-tab filename start-pos end-pos))
       
       ;; reopen-closed-tab : -> void
       ;; Opens previously closed tabs. If no tabs were closed in current session, files from 
@@ -3421,7 +3422,7 @@
       ;; truncate-list : (listof X) -> (listof X)[< new-len]
       ;; takes a list and returns the
       ;; front of the list, up to 'new-len' number of items
-      (define (truncate-list l new-len)
+      (define/private (truncate-list l new-len)
         (define len (length l))
           (cond
             [(<= len new-len) l]
@@ -4110,7 +4111,7 @@
         (mk-menu-item (λ (ed) (send ed get-spell-check-text)) 
                       (λ (ed new-val) (send ed set-spell-check-text new-val))
                       'framework:spell-check-text?
-                      #\t
+                      #f
                       (string-constant spell-check-scribble-text))
         
         (new menu:can-restore-menu-item%

--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -3269,7 +3269,8 @@
         (create-new-tab filename))
       
       ;; reopen-closed-tab : -> void
-      ;; opens previously closed tab if the file still exists
+      ;; Opens previously closed tabs. If no tabs were closed in current session, files from 
+      ;; previous sessions are opened.
       (define/public reopen-closed-tab
         (lambda ()
           ; Get the list of recently opened files

--- a/drracket/scribblings/drracket/menus.scrbl
+++ b/drracket/scribblings/drracket/menus.scrbl
@@ -30,6 +30,10 @@
         or @litchar{"x.rkt"})
         and edit the corresponding files in the @tech{definitions window}.}
 
+ @item{@defmenuitem{Reopen Closed Tab} Opens previously closed tabs. 
+        If no tabs were closed in current session, files from 
+        previous sessions are opened.}
+
  @item{@defmenuitem{Install PLT File...} Opens a dialog asking for the
    location of the @filepath{.plt} file (either on the local disk or
    on the web) and installs the contents of the file.}

--- a/drracket/scribblings/tools/unit.scrbl
+++ b/drracket/scribblings/tools/unit.scrbl
@@ -620,12 +620,12 @@ Returns the currently active tab.
 }
 
 @defmethod[(open-in-new-tab [filename (or/c path-string? #f)]
-                            [start exact-nonnegative-integer? 0]
-                            [end (or/c exact-nonnegative-integer? 'same) 'same]) 
+                            [#:start-pos start-pos exact-nonnegative-integer? 0]
+                            [#:end-pos end-pos (or/c exact-nonnegative-integer? 'same) 'same]) 
                             void?]{
   Opens a new tab in this frame. If @racket[filename] is a @racket[path-string?],
-  It loads that file in the definitions window of the new tab. If @racket[start] and 
-  @racket[end] are provided, it updates the tab's corresponding insertion positions. 
+  It loads that file in the definitions window of the new tab. If @racket[start-pos] and 
+  @racket[end-pos] are provided, it updates the tab's corresponding insertion positions. 
 }
 
 @defmethod[(create-new-tab) void?]{

--- a/drracket/scribblings/tools/unit.scrbl
+++ b/drracket/scribblings/tools/unit.scrbl
@@ -628,6 +628,10 @@ Returns the currently active tab.
   Creates a new tab.
 }
 
+@defmethod[(reopen-closed-tab) void?]{
+  Opens the most recently closed tabs. 
+}
+
 @defmethod[(next-tab) void?]{
   Switches to the next tab.
 }

--- a/drracket/scribblings/tools/unit.scrbl
+++ b/drracket/scribblings/tools/unit.scrbl
@@ -619,9 +619,13 @@ Returns the currently active tab.
   Returns the number of open tabs in the frame.
 }
 
-@defmethod[(open-in-new-tab [filename (or/c path-string? #f)]) void?]{
+@defmethod[(open-in-new-tab [filename (or/c path-string? #f)]
+                            [start exact-nonnegative-integer? 0]
+                            [end (or/c exact-nonnegative-integer? 'same) 'same]) 
+                            void?]{
   Opens a new tab in this frame. If @racket[filename] is a @racket[path-string?],
-  It loads that file in the definitions window of the new tab.
+  It loads that file in the definitions window of the new tab. If @racket[start] and 
+  @racket[end] are provided, it updates the tab's corresponding insertion positions. 
 }
 
 @defmethod[(create-new-tab) void?]{


### PR DESCRIPTION
As discussed in Issue #508 , this PR implements the functionality for reopening previously closed tabs. It has been added to the file menu after `Open Require Path...` as 'Reopen Closed Tab'. Since `Ctrl-Shift-T` is reserved for 'Spell Check Test' in the edit menu, I gave this the shortcut `Ctrl-*`, which might be a bit unintuitive.

As in [@Metaxal 's quickscript](https://gist.github.com/Metaxal/56d288626574debac24b41fb0232bbe1), the callback `reopen-closed-tab` finds the first file in recently-opened-files that isn't already open and still exists. If no tabs were closed in the current session, it will open files that were active in previous sessions. However, after the recently-opened-files list is exhausted, it will just open new tabs. I thought it would be best for the callback to reside in [unit.rkt](https://github.com/squarebat/drracket/blob/862310dfdc7937fe9bdf352a56e4819b46a9d49f/drracket/drracket/private/unit.rkt) where related methods `create-new-tab` and `open-in-new-tab` are stored.

This has only been manually tested, how should I write the tests for it? I couldn't find an appropriate file in the repository for testing GUI related features. 

I will admit I couldn't look into this issue for a long time, and I am extremely sorry about the delay ;-;

The corresponding PR to add the new string constant reopen-closed-tab - [string-constants/pull/56](https://github.com/racket/string-constants/pull/56)