### PR TITLE
use the regular rackunit

### DIFF
--- a/drracket/drracket/private/tooltip.rkt
+++ b/drracket/drracket/private/tooltip.rkt
@@ -217,7 +217,7 @@
 
 
 (module+ test
-  (require typed/rackunit)
+  (require rackunit)
   (check-equal? (strings->strings+spacers '()) '())
   (check-equal? (strings->strings+spacers '("x")) '(("" "x")))
   (check-equal? (strings->strings+spacers '("x" "x")) '(("" "x") ("" "x")))


### PR DESCRIPTION
Found by [running tests against changes](https://github.com/racket/rackunit/pull/153) that enable syntax location for typed rackunit:

```
2022-01-20T16:41:00.3310133Z raco setup: --- summary of errors ---                              [16:41:00]
2022-01-20T16:41:00.3311127Z raco setup:   /github/home/racketdist-current-CS/share/pkgs/drracket/drracket/private/tooltip.rkt:221:2: Type Checker: Macro check-equal? from typed module used in untyped code
2022-01-20T16:41:00.3311894Z raco setup:     in: (check-equal? (strings->strings+spacers (quote ())) (quote ()))
2022-01-20T16:41:00.3312711Z raco setup:     compiling: <pkgs>/drracket/drracket/private/tooltip.rkt
2022-01-20T16:41:00.3319483Z raco pkg install: packages installed, although setup reported errors
2022-01-20T16:41:00.3880671Z ##[error]Process completed with exit code 1.
```
 
we can fix the problem on our end, ~but I don't see why `typed/rackunit` was used here.~
[Edit]: this file used to be typed 