### PR TITLE
Fix representation of debugging information

### DIFF
--- a/drracket-test/tests/drracket/errortrace-module.rkt
+++ b/drracket-test/tests/drracket/errortrace-module.rkt
@@ -1,0 +1,48 @@
+#lang at-exp racket/base
+(require "private/drracket-test-util.rkt"
+         framework/test
+         racket/class
+         rackunit)
+
+(define (setup-racket/base-raw) (setup/rb "No debugging or profiling"))
+(define (setup-racket/base-debug) (setup/rb "Debugging"))
+(define (setup-racket/base-profile) (setup/rb "Debugging and profiling"))
+(define (setup-racket/base-coverage) (setup/rb "Syntactic test suite coverage"))
+
+(define (setup/rb which-rb)
+  (set-module-language! #f)
+  (test:set-radio-box-item! which-rb)
+  (let ([f (test:get-active-top-level-window)])
+    (test:button-push "OK")
+    (wait-for-new-frame f)))
+
+;; this test runs a program with an error and checks to make
+;; sure that the stack dialog pops up and it either does or
+;; does not have an errortrace-based stack, as appropriate
+(define (check-errortrace-module setup-language)
+  (define drracket-frame (wait-for-drracket-frame))
+
+  (define ints-text (queue-callback/res (λ () (send drracket-frame get-interactions-text))))
+
+  (setup-language)
+  (clear-definitions drracket-frame)
+  (insert-in-definitions
+   drracket-frame
+   @string-append{
+    #lang errortrace racket/base
+    (error 'foobar)
+    })
+
+  (do-execute drracket-frame)
+
+  (define ints-content (queue-callback/res (λ () (send ints-text get-text))))
+  (check-regexp-match #rx"error: foobar\n  errortrace\\.\\.\\.:"
+                      ints-content))
+
+(fire-up-drracket-and-run-tests
+ (λ ()
+   (check-errortrace-module setup-racket/base-raw)
+   (check-errortrace-module setup-racket/base-debug)
+   (check-errortrace-module setup-racket/base-profile)
+   (check-errortrace-module setup-racket/base-coverage)
+   ))

--- a/drracket/drracket/private/eval-helpers-and-pref-init.rkt
+++ b/drracket/drracket/private/eval-helpers-and-pref-init.rkt
@@ -198,6 +198,9 @@
   ;; inputs to stacktrace/errortrace-annotate@ that are used both
   ;; in debug.rkt and also for online expansion
 
+(define stx-info
+  (unquoted-printing-string "omitted; see the stacktrace for more information"))
+
 ;; make-with-mark : (any/c -> any/c) -> mark-stx syntax natural -> syntax
 ;; the result of the first application should be bound to `with-mark`,
 ;; a member of stacktrace-imports^
@@ -215,7 +218,7 @@
      (define line (or (syntax-line src-stx) 0))
      (define column (or (syntax-column src-stx) 0))
      (with-syntax ([expr expr]
-                   [mark (list 'dummy-thing source line column position span)]
+                   [mark (list stx-info source line column position span)]
                    [et-key (syntax-shift-phase-level #'errortrace-key phase)]
                    [wcm (syntax-shift-phase-level #'with-continuation-mark phase)]
                    [qte (syntax-shift-phase-level #'quote phase)])

--- a/drracket/drracket/private/eval-helpers-and-pref-init.rkt
+++ b/drracket/drracket/private/eval-helpers-and-pref-init.rkt
@@ -215,7 +215,7 @@
      (define line (or (syntax-line src-stx) 0))
      (define column (or (syntax-column src-stx) 0))
      (with-syntax ([expr expr]
-                   [mark (vector source line column position span)]
+                   [mark (list 'dummy-thing source line column position span)]
                    [et-key (syntax-shift-phase-level #'errortrace-key phase)]
                    [wcm (syntax-shift-phase-level #'with-continuation-mark phase)]
                    [qte (syntax-shift-phase-level #'quote phase)])

--- a/drracket/drracket/private/stack-checkpoint.rkt
+++ b/drracket/drracket/private/stack-checkpoint.rkt
@@ -176,11 +176,7 @@
                         a-viewable-stack))
 
 (define (errortrace-stack-item->srcloc x)
-  (make-srcloc (vector-ref x 0)
-               (vector-ref x 1)
-               (vector-ref x 2)
-               (vector-ref x 3)
-               (vector-ref x 4)))
+  (apply make-srcloc (cdr x)))
 
 (define (cms->builtin-viewable-stack cms interesting-editors
                                      #:share-cache [a-viewable-stack #f])


### PR DESCRIPTION
Make the representation of debugging information coincide with that
from errortrace, so that #lang errortrace works properly in DrRacket.
This PR essentially reverts f4c495b27e5db5e9.

Fixes #564