### PR TITLE
remove second dependency from drracket-tool-lib on drracket-tool-text…

### DIFF
--- a/drracket-tool-lib/info.rkt
+++ b/drracket-tool-lib/info.rkt
@@ -8,8 +8,7 @@
                ["string-constants-lib" #:version "1.43"]
                "scribble-lib"
                "racket-index"
-               "gui-lib"
-               "drracket-tool-text-lib"))
+               "gui-lib"))
 (define build-deps '("at-exp-lib"
                      "rackunit-lib"))
 


### PR DESCRIPTION
While I'm still thinking of it, this PR removes the second dependency from tool-lib on tool-text-lib.