### PR TITLE
add syncheck:import-or-export-prefix-ranges

### DIFF
--- a/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
+++ b/drracket-tool-doc/scribblings/drracket-tools/drracket-tools.scrbl
@@ -472,6 +472,25 @@ in order to make the results be platform independent.
     This method is listed only for backwards compatibility. It is not called
     by Check Syntax anymore.
   }
+
+
+ @defmethod[(syncheck:import-or-export-prefix-ranges
+             [id identifier?]
+             [ranges (listof (vector/c natural?
+                                       natural?
+                                       identifier?
+                                       #:immutable #t))])
+            void?]{
+  This method is called to indicate the locations of prefixes of
+  identifiers when provide or rename macros like @racket[prefix-out]
+  or @racket[prefix-in] are used. It is called once for each identifier
+  that was constructed by some number (at least one) prefixing operation.
+  The first argument is the identifier and the second argument gives
+  the source locations of the actual prefixes in the prefix declarations.
+
+  @history[#:added "1.4"]
+ }
+                  
 }
 
 @defmixin[annotations-mixin () (syncheck-annotations<%>)]{
@@ -561,7 +580,8 @@ in order to make the results be platform independent.
                     syncheck:add-id-set 
                     syncheck:color-range
                     syncheck:add-prefixed-require-reference
-                    syncheck:add-unused-require]
+                    syncheck:add-unused-require
+                    syncheck:import-or-export-prefix-ranges]
 
 @section{Module Browser}
 

--- a/drracket-tool-text-lib/drracket/private/syncheck/annotate.rkt
+++ b/drracket-tool-text-lib/drracket/private/syncheck/annotate.rkt
@@ -62,4 +62,3 @@
 ;; find-source-editor : stx text -> editor or false
 (define (find-source-editor/defs stx defs-text)
   (send defs-text syncheck:find-source-object stx))
-

--- a/drracket-tool-text-lib/drracket/private/syncheck/syncheck-intf.rkt
+++ b/drracket-tool-text-lib/drracket/private/syncheck/syncheck-intf.rkt
@@ -22,8 +22,8 @@
     syncheck:add-prefixed-require-reference
     syncheck:add-unused-require
     syncheck:color-range
-    
-    syncheck:add-rename-menu))
+    syncheck:add-rename-menu
+    syncheck:import-or-export-prefix-ranges))
 
 ;; use this to communicate the frame being
 ;; syntax checked w/out having to add new
@@ -80,6 +80,7 @@
                     prefix prefix-src prefix-pos-left prefix-pos-right)
       (void))
     (define/public (syncheck:add-unused-require req-src req-pos-left req-pos-right) (void))
+    (define/public (syncheck:import-or-export-prefix-ranges identifier ranges) (void))
     (super-new)))
 
 (provide syncheck-annotations<%>

--- a/drracket-tool-text-lib/drracket/private/syncheck/syncheck-local-member-names.rkt
+++ b/drracket-tool-text-lib/drracket/private/syncheck/syncheck-local-member-names.rkt
@@ -21,4 +21,5 @@
   syncheck:add-definition-target
   syncheck:add-definition-target/phase-level+space
   syncheck:add-prefixed-require-reference
-  syncheck:add-unused-require)
+  syncheck:add-unused-require
+  syncheck:import-or-export-prefix-ranges)

--- a/drracket-tool-text-lib/drracket/private/syncheck/traversals.rkt
+++ b/drracket-tool-text-lib/drracket/private/syncheck/traversals.rkt
@@ -15,6 +15,7 @@
          racket/pretty
          racket/path
          racket/dict
+         racket/math
          syntax/id-table
          scribble/manual-struct
          (for-syntax racket/base))
@@ -274,7 +275,8 @@
                                      sub-identifier-binding-directives
                                      level
                                      level-of-enclosing-module
-                                     mods))])
+                                     mods)
+              (collect-import-or-export-prefix-ranges stx))])
 
       (define (collect-nested-general-info stx)
         (let loop ([stx stx])
@@ -686,6 +688,26 @@
        (log-check-syntax-debug
         "found a vector in a 'sub-range-binders property that is ill-formed ~s"
         prop)])))
+
+(define import-or-export-prefix-ranges-prop?
+  (vector/c
+   identifier?
+   (listof (vector/c natural? natural? identifier?
+                     #:immutable #t))
+   #:immutable #t))
+
+(define (collect-import-or-export-prefix-ranges stx)
+  (define defs (current-annotations))
+  (when defs
+    (let loop ([prop (syntax-property stx 'import-or-export-prefix-ranges)])
+      (cond
+        [(pair? prop)
+         (loop (car prop))
+         (loop (cdr prop))]
+        [(import-or-export-prefix-ranges-prop? prop)
+         (send defs syncheck:import-or-export-prefix-ranges
+               (vector-ref prop 0)
+               (vector-ref prop 1))]))))
 
 (define mouse-over-tooltip-prop?
   (vector/c #:flat? #t syntax? exact-nonnegative-integer? exact-nonnegative-integer?

--- a/drracket-tool-text-lib/info.rkt
+++ b/drracket-tool-text-lib/info.rkt
@@ -13,7 +13,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.3")
+(define version "1.4")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/drracket/drracket/private/syncheck/gui.rkt
+++ b/drracket/drracket/private/syncheck/gui.rkt
@@ -2028,6 +2028,8 @@ If the namespace does not, they are colored the unbound color.
             (define/private (invalidate-bitmap-cache/padding)
               (define-values (l t r b) (get-padding))
               (invalidate-bitmap-cache l))
+
+            (define/public (syncheck:import-or-export-prefix-ranges id ranges) (void))
             
             (super-new)))))
     


### PR DESCRIPTION
Not sure if this is immediately (or ever?) useful, but it was easy to make and it seems like it fits here, so I made it.

Related to racket/racket#4649