### PR TITLE
add `drracket:define-popup` configuration to `#lang`-based `get-info`

### DIFF
--- a/drracket-plugin-lib/drracket/private/drsig.rkt
+++ b/drracket-plugin-lib/drracket/private/drsig.rkt
@@ -149,7 +149,9 @@
    (struct online-expansion-handler (mod-path id local-handler monitor?))
    get-online-expansion-handlers
    no-more-online-expansion-handlers
-   interactions-text-mixin))
+   interactions-text-mixin
+   call-capability-value
+   capability-value-irl))
 
 (define-signature drracket:get-collection-cm^ ())
 (define-signature drracket:get-collection^ extends drracket:get-collection-cm^

--- a/drracket/drracket/private/get-defs.rkt
+++ b/drracket/drracket/private/get-defs.rkt
@@ -15,7 +15,7 @@
 (define-struct defn (indent name start-pos end-pos)
   #:mutable #:transparent)
 
-(struct define-popup-info (prefix long-name short-name) #:transparent)
+(struct define-popup-info (prefix long-name short-name case-sensitive? delimited?) #:transparent)
 
 ;; get-define-popup-info :
 ;; valid-configurations-as-specified-in-the-drscheme:defined-popup-docs
@@ -24,12 +24,18 @@
   (cond
     [(not cap) #f]
     [((cons/c string? string?) cap)
-     (list (define-popup-info (car cap) (cdr cap) "δ"))]
+     (list (define-popup-info (car cap) (cdr cap) "δ" #f #f))]
     [((list/c string? string? string?) cap)
-     (list (define-popup-info (list-ref cap 0) (list-ref cap 1) (list-ref cap 2)))]
+     (list (define-popup-info (list-ref cap 0) (list-ref cap 1) (list-ref cap 2) #f #f))]
     [((listof (list/c string? string? string?)) cap)
      (for/list ([cap (in-list cap)])
-       (define-popup-info (list-ref cap 0) (list-ref cap 1) (list-ref cap 2)))]
+       (define-popup-info (list-ref cap 0) (list-ref cap 1) (list-ref cap 2) #f #f))]
+    [((listof (list/c string? string? string? (listof (or/c 'case-sensitive 'delimited))))
+      cap)
+     (for/list ([cap (in-list cap)])
+       (define-popup-info (list-ref cap 0) (list-ref cap 1) (list-ref cap 2)
+         (and (memq 'case-sensitive (list-ref cap 3)) #t)
+         (and (memq 'delimited (list-ref cap 3)) #t)))]
     [else #f]))
   
 
@@ -52,10 +58,13 @@
           [else
            (define tag-string (define-popup-info-prefix a-define-popup-info))
            (let loop ([pos pos])
-             (define search-pos-result (send text find-string tag-string 'forward pos 'eof #t #f))
+             (define search-pos-result (send text find-string tag-string 'forward pos 'eof #t
+                                             (define-popup-info-case-sensitive? a-define-popup-info)))
              (cond
                [(and search-pos-result
-                     (in-semicolon-comment? text search-pos-result))
+                     (or (in-comment-or-text? text search-pos-result)
+                         (and (define-popup-info-delimited? a-define-popup-info)
+                              (not (delimited-text? text search-pos-result (+ search-pos-result (string-length tag-string)))))))
                 (if (< search-pos-result (send text last-position))
                     (loop (+ search-pos-result 1))
                     +inf.0)]
@@ -122,16 +131,19 @@
                        (defn-name defn)))))
   defs)
 
-;; in-semicolon-comment: text number -> boolean
-;; returns #t if `define-start-pos' is in a semicolon comment and #f otherwise
-(define (in-semicolon-comment? text define-start-pos)
-  (let* ([para (send text position-paragraph define-start-pos)]
-         [start (send text paragraph-start-position para)])
-    (let loop ([pos start])
-      (cond
-        [(pos . >= . define-start-pos) #f]
-        [(char=? #\; (send text get-character pos)) #t]
-        [else (loop (+ pos 1))]))))
+;; in-comment-or-text?: text number -> boolean
+;; returns #t if `define-start-pos' is in a comment or text according
+;; to coloring information, #f otherwise
+(define (in-comment-or-text? text define-start-pos)
+  (case (send text classify-position define-start-pos)
+    [(comment text string) #t]
+    [else #f]))
+
+(define (delimited-text? text start-pos end-pos)
+  (and (equal? end-pos
+               (send text forward-match start-pos (send text last-position)))
+       (equal? start-pos
+               (send text backward-match end-pos 0))))
 
 ;; get-defn-indent : text number -> number
 ;; returns the amount to indent a particular definition
@@ -227,20 +239,53 @@
     (send t insert "(module m racket/base)\n")
     (check-equal?
      (get-definitions
-      (list (define-popup-info "(define" "(define ...)" "δ")
-            (define-popup-info "(module" "(module ...)" "ρ"))
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f)
+            (define-popup-info "(module" "(module ...)" "ρ" #f #f))
       #t
       t)
+     ;; the 18 in the first element of this list
+     ;; might actually supposed to be 17
+     ;; (and other test cases similarly)
      (list (defn 0 "f" 0 18)
            (defn 2 "  g" 19 35)
            (defn 0 "m" 36 59)))
     (check-equal?
      (get-definitions
-      (list (define-popup-info "(module" "(module ...)" "ρ"))
+      (list (define-popup-info "(module" "(module ...)" "ρ" #f #f))
       #t
       t)
      (list (defn 0 "m" 36 59))))
 
+  (let ()
+    (define t (new racket:text%))
+    (send t insert "(dEfInE (f x) x)\n")
+    (check-equal?
+     (get-definitions
+      (list (define-popup-info "(define" "(define ...)" "δ" #t #f))
+      #t
+      t)
+     (list)))
+
+  (let ()
+    (define t (new racket:text%))
+    (send t insert "(dEfInE (f x) x)\n")
+    (check-equal?
+     (get-definitions
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f))
+      #t
+      t)
+     (list (defn 0 "f" 0 17))))
+
+  (let ()
+    (define t (new racket:text%))
+    (send t insert "(define (f x) x)\n")
+    (check-equal?
+     (get-definitions
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #t))
+      #t
+      t)
+     (list)))
+  
   (let ()
     (define t (new racket:text%))
     (send t insert "(define-metafunction L\n")
@@ -248,7 +293,7 @@
     (send t insert "  [(M any_1) any_1])\n")
     (check-equal?
      (get-definitions
-      (list (define-popup-info "(define" "(define ...)" "δ"))
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f))
       #t
       t)
      (list (defn 0 "M" 0 61))))
@@ -259,7 +304,7 @@
     (send t insert "  [(M any_1) any_1])\n")
     (check-equal?
      (get-definitions
-      (list (define-popup-info "(define" "(define ...)" "δ"))
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f))
       #t
       t)
      (list (defn 0 "M" 0 44))))
@@ -269,7 +314,7 @@
     (send t insert "(define (|(| x) x)\n")
     (check-equal?
      (get-definitions
-      (list (define-popup-info "(define" "(define ...)" "δ"))
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f))
       #t
       t)
      (list (defn 0 "|(|" 0 19))))
@@ -279,7 +324,17 @@
     (send t insert "(define)\n")
     (check-equal?
      (get-definitions
-      (list (define-popup-info "(define" "(define ...)" "δ"))
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f))
+      #t
+      t)
+     (list (defn 0 "<< end of buffer >>" 0 9))))
+
+  (let ()
+    (define t (new racket:text%))
+    (send t insert "(define)\n")
+    (check-equal?
+     (get-definitions
+      (list (define-popup-info "(define" "(define ...)" "δ" #f #f))
       #t
       t)
      (list (defn 0 "<< end of buffer >>" 0 9))))

--- a/drracket/drracket/private/in-irl-namespace.rkt
+++ b/drracket/drracket/private/in-irl-namespace.rkt
@@ -215,6 +215,9 @@
      (or/c #f (listof symbol?))]
     [(drracket:paren-matches) (or/c #f (listof (list/c symbol? symbol?)))]
     [(drracket:quote-matches) (or/c #f (listof char?))]
+    [(drracket:define-popup) (or/c #f
+                                   (non-empty-listof (list/c string? string? string?))
+                                   (non-empty-listof (list/c string? string? string? (listof (or/c 'case-sensitive 'delimited)))))]
     [else
      (error 'key->contract "unknown key")]))
 

--- a/drracket/drracket/private/insulated-read-language.rkt
+++ b/drracket/drracket/private/insulated-read-language.rkt
@@ -43,7 +43,8 @@ Will not work with the definitions text surrogate interposition that
         'color-lexer
         'definitions-text-surrogate
         'drracket:paren-matches
-        'drracket:quote-matches))
+        'drracket:quote-matches
+        'drracket:define-popup))
 
 (provide
  (contract-out

--- a/drracket/drracket/private/local-member-names.rkt
+++ b/drracket/drracket/private/local-member-names.rkt
@@ -57,6 +57,7 @@
   fetch-data-to-send
   clear-old-error
   set-bottom-bar-status
+  set-define-menu
   
   get-oc-status
   set-oc-status

--- a/drracket/drracket/private/local-member-names.rkt
+++ b/drracket/drracket/private/local-member-names.rkt
@@ -57,7 +57,7 @@
   fetch-data-to-send
   clear-old-error
   set-bottom-bar-status
-  set-define-menu
+  update-func-defs
   
   get-oc-status
   set-oc-status

--- a/drracket/drracket/private/module-language-tools.rkt
+++ b/drracket/drracket/private/module-language-tools.rkt
@@ -318,6 +318,7 @@
                get-keymap)
       (define in-module-language? #f)      ;; true when we are in the module language
       (define hash-lang-language #f)       ;; non-false is the string that was parsed for the language
+      (define define-popup-info #f)
 
       ;; non-false means that an edit before this location
       ;; means that the language might have changed
@@ -537,7 +538,18 @@
            (and drracket-opt-out drscheme-opt-out
                 (append drracket-opt-out drscheme-opt-out)))
 
-         (call-read-language the-irl 'drracket:opt-in-toolbar-buttons '())))
+         (call-read-language the-irl 'drracket:opt-in-toolbar-buttons '()))
+
+        (let ([spec (call-read-language the-irl 'drracket:define-popup #f)])
+          (set! define-popup-info spec)
+          (when spec
+            (define frame (send (get-tab) get-frame))
+            (send frame when-initialized
+                  (λ ()
+                    (send frame set-define-menu spec))))))
+
+      (define/public (get-define-menu)
+        define-popup-info)
 
       ;; removes language-specific customizations
       (define/private (clear-things-out)

--- a/drracket/drracket/private/module-language.rkt
+++ b/drracket/drracket/private/module-language.rkt
@@ -236,8 +236,11 @@
           [(eq? key 'drscheme:autocomplete-words)
            (drracket:language-configuration:get-all-manual-keywords)]
           [(eq? key 'drscheme:define-popup)
-           '(("(define" "(define ...)" "δ")
-             ("(module" "(module ...)" "ρ"))]
+           (define the-irl (drracket:module-language-tools:capability-value-irl))
+           (call-read-language the-irl
+                               'drracket:define-popup
+                               '(("(define" "(define ...)" "δ")
+                                 ("(module" "(module ...)" "ρ")))]
           [else (drracket:language:get-capability-default key)]))
       
       ;; config-panel : as in super class

--- a/drracket/drracket/private/rep.rkt
+++ b/drracket/drracket/private/rep.rkt
@@ -59,6 +59,7 @@ TODO
           [prefix drracket:debug: drracket:debug/int^]
           [prefix drracket:eval: drracket:eval^]
           [prefix drracket:module-language: drracket:module-language/int^]
+          [prefix drracket:module-language-tools: drracket:module-language-tools/int^]
           [prefix drracket: drracket:interface^])
   (export (rename drracket:rep/int^
                   [-text% text%]
@@ -197,10 +198,14 @@ TODO
             [else
              (let* ([l (send obj get-canvas)]
                     [l (and l (send l get-top-level-window))]
-                    [l (and l (is-a? l drracket:unit:frame<%>) (send l get-definitions-text))]
-                    [l (and l (send l get-next-settings))]
+                    [defs (and l (is-a? l drracket:unit:frame<%>) (send l get-definitions-text))]
+                    [l (and defs (send defs get-next-settings))]
                     [l (and l (drracket:language-configuration:language-settings-language l))]
-                    [ctxt (and l (send l capability-value 'drscheme:help-context-term))]
+                    [ctxt (and l
+                               (drracket:module-language-tools:call-capability-value
+                                l
+                                defs
+                                'drscheme:help-context-term))]
                     [name (and l (send l get-language-name))])
                (drracket:help-desk:help-desk
                 str (and ctxt (list ctxt name)) frame))])]
@@ -2310,7 +2315,10 @@ TODO
           (let* ([definitions-text (get-defs this)]
                  [settings (send definitions-text get-next-settings)]
                  [language (drracket:language-configuration:language-settings-language settings)])
-            (send language capability-value 'drscheme:autocomplete-words)))
+            (drracket:module-language-tools:call-capability-value
+             language
+             definitions-text
+             'drscheme:autocomplete-words)))
         (super-new))))
   
   (define -text% 

--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -117,7 +117,7 @@
           [prefix drracket:tools: drracket:tools^]
           [prefix drracket:init: drracket:init/int^]
           [prefix drracket:module-language: drracket:module-language/int^]
-          [prefix drracket:module-language-tools: drracket:module-language-tools^]
+          [prefix drracket:module-language-tools: drracket:module-language-tools/int^]
           [prefix drracket:modes: drracket:modes^]
           [prefix drracket:debug: drracket:debug^]
           [prefix drracket: drracket:interface^])
@@ -207,7 +207,13 @@
                [l (and l (is-a? l drracket:unit:frame<%>) (send l get-definitions-text))]
                [l (and l (send l get-next-settings))]
                [l (and l (drracket:language-configuration:language-settings-language l))]
-               [ctxt (and l (send l capability-value 'drscheme:help-context-term))]
+               [ctxt (and l
+                          (drracket:module-language-tools:call-capability-value
+                           l
+                           (if (is-a? text drracket:rep:text%)
+                               (send text get-definitions-text)
+                               text)
+                           'drscheme:help-context-term))]
                [name (and l (send l get-language-name))])
           (unless (string=? str "")
             (add-sep)
@@ -1009,7 +1015,10 @@
                                    language-settings)]
                     [capability-info
                      (get-define-popup-info
-                      (send new-language capability-value 'drscheme:define-popup))])
+                      (drracket:module-language-tools:call-capability-value
+                       new-language
+                       (send frame get-definitions-text)
+                       'drscheme:define-popup))])
                (when capability-info
                  (let* ([current-pos (get-pos editor event)]
                         [current-word (and current-pos (get-current-word editor current-pos))]
@@ -1069,16 +1078,14 @@
         (get-define-popup-info
          (drracket:language:get-capability-default 'drscheme:define-popup)))
 
-      (define/public (set-define-menu spec vertical?)
-        (set! define-popup-capability-info (get-define-popup-info spec))
-        (set-message-at-orientation vertical?))
-      
       (inherit set-message set-hidden?)
-      (define/public (language-changed new-language current-define-popup-info vertical?)
+      (define/public (language-changed new-language vertical?)
         (set! define-popup-capability-info
               (get-define-popup-info
-               (or current-define-popup-info
-                   (send new-language capability-value 'drscheme:define-popup))))
+               (drracket:module-language-tools:call-capability-value
+                new-language
+                (send frame get-definitions-text)
+                'drscheme:define-popup)))
         (set-message-at-orientation vertical?))
       (define/public (set-message-at-orientation vertical?)
         (define define-name
@@ -2244,9 +2251,7 @@
       (define/public (language-changed)
         (define settings (send definitions-text get-next-settings))
         (define language (drracket:language-configuration:language-settings-language settings))
-        (define define-popup-info (send definitions-text get-define-menu))
-        (send func-defs-canvas language-changed language define-popup-info (or (toolbar-is-left?)
-                                                                               (toolbar-is-right?)))
+        (update-func-defs)
         (send language-message set-yellow/lang
               (not (send definitions-text this-and-next-language-the-same?))
               (string-append (send language get-language-name)
@@ -2259,15 +2264,19 @@
         (update-teachpack-menu)
         (when (is-a? language-specific-menu menu%)
           (define label (send language-specific-menu get-label))
-          (define new-label (send language capability-value 'drscheme:language-menu-title))
+          (define new-label
+            (drracket:module-language-tools:call-capability-value
+             language (get-definitions-text) 'drscheme:language-menu-title))
           (unless (equal? label new-label)
             (send language-specific-menu set-label new-label))))
       
       (define/public (get-language-menu) language-specific-menu)
 
-      (define/public (set-define-menu spec)
-        (send func-defs-canvas set-define-menu spec (or (toolbar-is-left?)
-                                                        (toolbar-is-right?))))
+      (define/public (update-func-defs)
+        (define settings (send definitions-text get-next-settings))
+        (define language (drracket:language-configuration:language-settings-language settings))
+        (send func-defs-canvas language-changed language (or (toolbar-is-left?)
+                                                             (toolbar-is-right?))))
       
       ;; update-save-message : -> void
       ;; sets the save message. If input is #f, uses the frame's
@@ -4338,7 +4347,8 @@
         (define language-settings (send (get-definitions-text) get-next-settings))
         (define new-language
           (drracket:language-configuration:language-settings-language language-settings))
-        (send new-language capability-value key))
+        (drracket:module-language-tools:call-capability-value
+         new-language (get-definitions-text) key))
       
       (define language-menu 'uninited-language-menu)
       (define language-specific-menu 'language-specific-menu-not-yet-init)
@@ -4422,8 +4432,11 @@
                                 (filter
                                  values
                                  (map (λ (l) 
-                                        (and 
-                                         (send l capability-value 'drscheme:teachpack-menu-items)
+                                        (and
+                                         (drracket:module-language-tools:call-capability-value
+                                          l
+                                          (get-definitions-text)
+                                          'drscheme:teachpack-menu-items)
                                          (format "\n  ~a" (send l get-language-name))))
                                       (drracket:language-configuration:get-languages))))))
                              this
@@ -4572,7 +4585,8 @@
                  (define settings (send defs get-next-settings))
                  (define language 
                    (drracket:language-configuration:language-settings-language settings))
-                 (send language capability-value 'drscheme:tabify-menu-callback))])
+                 (drracket:module-language-tools:call-capability-value
+                  language defs 'drscheme:tabify-menu-callback))])
           (new menu:can-restore-menu-item%
                [label (string-constant reindent-menu-item-label)]
                [parent language-specific-menu]

--- a/drracket/drracket/tool-lib.rkt
+++ b/drracket/drracket/tool-lib.rkt
@@ -1723,19 +1723,26 @@ all of the names in the tools library, for use defining keybindings
              (or/c #f
                    (list/c string? string? string?)
                    (non-empty-listof (list/c string? string? string?))
+                   (non-empty-listof (list/c string? string? string?
+                                             (listof (or/c 'case-insensitive 'delimited))))
                    (cons/c string? string?))
              (list "(define" "(define ...)" "δ")]{
           specifies the prefix that the define popup should look for and what
           label it should have, or @racket[#f] if it should not appear at all.
+          Text is found only when it is not in a comment or string literal.
           
           If the list of three strings alternative is used, the first string is
           the prefix that is looked for when finding definitions. The second
           and third strings are used as the label of the control, in horizontal
           and vertical mode, respectively.
 
-          If it is a list of lists of three strings, then multiple prefixes are used
+          If it is a list of lists, then multiple prefixes are used
           for the definition pop-up. The name of the popup menu is based only on the
-          first element of the list.
+          first element of the list. When a nested list contains a list of symbols,
+          the symbols refine the matching strategy: @scheme['case-insensitive] for
+          case-insensitive matching, and @scheme['delimited] to indicate that the
+          matched text's edges must coincide with forward and backward expression
+          nagivation.
           
           The pair of strings alternative is deprecated. If it is used, 
           the pair @racket[(cons a-str b-str)] is the same as @racket[(list a-str b-str "δ")].

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -67,7 +67,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.13")
+(define version "1.14")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -52,6 +52,7 @@ DrRacket calls the language's @racket[read-language]'s
          @item{@language-info-ref[drracket:opt-in-toolbar-buttons]}
          @item{@language-info-ref[drracket:submit-predicate]}
          @item{@language-info-ref[drracket:toolbar-buttons]}
+         @item{@language-info-ref[drracket:define-popup]}
          @item{@language-info-ref[color-lexer]}
          @item{@language-info-ref[definitions-text-surrogate]}]
 
@@ -357,6 +358,43 @@ pass @indexed-racket['drscheme:toolbar-buttons]; this is for backwards
 compatibility and new code should not use it.
 Similarly, if the fourth element from the list (the argument to @racket[#:number])
 is not present, then it is treated as @racket[#f].
+
+@section{Definition Popup-Menu Navigation}
+
+@language-info-def[drracket:define-popup]{
+ A popup menu in the DrRacket button bar jumps to definitions based on a
+ heuristic search of the program text.
+ DrRacket will invoke the @racket[_get-info] proc returned by @racket[read-language] with
+ @racket['drracket:define-popup] to obtain a configuration for the menu.
+
+ The value must satisfy the contract
+
+ @racketblock[
+   (non-empty-listof (or/c (list/c string? string? string?)
+                           (list/c string? string? string?
+                                   (listof (or/c 'case-sensitive 'delimited)))))
+  ]
+
+ where the first string in each nested list is literal text to search
+ for (outside of comments and literal strings), the second string is a
+ label to describe the category of matches, and the third string is a
+ short form of the label. The labels from the first nested list are
+ used for the definition-popup button itself, while all labels are
+ used for the user to select which categories are enabled.
+
+ If a list of symbols is provided, it refines the matching strategy.
+ By default, the literal text to find for a definition is found
+ case-insensitively, but @racket['case-sensitive] enables a
+ case-sensitive match. If @racket['delimited] is specified, then the
+ text must match a token completely in the sense that
+ expression-navigating forward or backward from one end will find the
+ other end of the text.
+
+ Plugins can provide a default popup-menu configuration via
+ @racket[drracket:language:register-capability] using @racket['drscheme:define-popup].
+
+ @history[#:added "1.14"]
+}
 
 @section[#:tag "sec:definitions-text-surrogate"]{Definitions Text Surrogate}
 


### PR DESCRIPTION
This change allows Rhombus to configure DrRacket so that the `(define ...)` menu becomes a `def` menu that jumps to Rhombus definitions.

Besides allowing `#lang`-based configuration, the change refines how the definition popup works:

 * Instead of looking for Scheme-style comments, recognize text that should not match based on its syntax-coloring category, ignoring would-be matches in comments or in string literals.

 * Allow the configuration to specify case-sensitive matching and delimited matching, where the definition of "delimited" is derived from the expression-navigation configuration.