### PR TITLE
generalize `drracket:define-popup` to callbacks

### DIFF
--- a/drracket/drracket/private/in-irl-namespace.rkt
+++ b/drracket/drracket/private/in-irl-namespace.rkt
@@ -217,7 +217,19 @@
     [(drracket:quote-matches) (or/c #f (listof char?))]
     [(drracket:define-popup) (or/c #f
                                    (non-empty-listof (list/c string? string? string?))
-                                   (non-empty-listof (list/c string? string? string? (listof (or/c 'case-sensitive 'delimited)))))]
+                                   (non-empty-listof (list/c string? string? string?
+                                                             (or/c #f
+                                                                   (-> read-only-text/c string? exact-integer?
+                                                                       (->* (read-only-text/c string? exact-integer?)
+                                                                            (#:case-sensitive? any/c
+                                                                             #:delimited? any/c)
+                                                                            (or/c exact-integer? #f))
+                                                                       (or/c exact-integer? #f)))
+                                                             (or/c #f
+                                                                   (-> read-only-text/c exact-integer?
+                                                                       (-> read-only-text/c exact-integer?
+                                                                           string?)
+                                                                       string?)))))]
     [else
      (error 'key->contract "unknown key")]))
 

--- a/drracket/drracket/private/insulated-read-language.rkt
+++ b/drracket/drracket/private/insulated-read-language.rkt
@@ -268,6 +268,27 @@ Will not work with the definitions text surrogate interposition that
      (or val racket:default-paren-matches)]
     [(drracket:quote-matches)
      (or val (list #\" #\|))]
+    [(drracket:define-popup)
+     (and val
+          (for/list ([val (in-list val)])
+            (match val
+              [(list n1 n2 n3) val]
+              [(list n1 n2 n3 p1 p2)
+               (list n1 n2 n3
+                     (and p1
+                          (λ (a b c f)
+                            (call-in-irl-context/abort
+                             an-irl
+                             #f
+                             (λ () (p1 a b c f)))))
+                     (and p2
+                          (λ (a b f)
+                            (call-in-irl-context/abort
+                             an-irl
+                             "<<no name>>" ;; we shouldn't
+                             ;; ever see this string because
+                             ;; the procedure above always returns #f
+                             (λ () (p2 a b f))))))])))]
     [else
      val]))
   

--- a/drracket/drracket/tool-lib.rkt
+++ b/drracket/drracket/tool-lib.rkt
@@ -1724,7 +1724,24 @@ all of the names in the tools library, for use defining keybindings
                    (list/c string? string? string?)
                    (non-empty-listof (list/c string? string? string?))
                    (non-empty-listof (list/c string? string? string?
-                                             (listof (or/c 'case-insensitive 'delimited))))
+                                             (or/c #f
+                                                   (-> (is-a/c text%)
+                                                       string?
+                                                       exact-integer?
+                                                       (->* ((is-a/c text%)
+                                                             string?
+                                                             exact-integer?)
+                                                            (#:case-sensitive? any/c
+                                                             #:delimited? any/c)
+                                                            (or/c exact-integer? #f))
+                                                       (or/c exact-integer? #f)))
+                                             (or/c #f
+                                                   (-> (is-a/c text%)
+                                                       exact-integer?
+                                                       (-> (is-a/c text%)
+                                                           exact-integer?
+                                                           string?)
+                                                       string?))))
                    (cons/c string? string?))
              (list "(define" "(define ...)" "δ")]{
           specifies the prefix that the define popup should look for and what
@@ -1738,11 +1755,10 @@ all of the names in the tools library, for use defining keybindings
 
           If it is a list of lists, then multiple prefixes are used
           for the definition pop-up. The name of the popup menu is based only on the
-          first element of the list. When a nested list contains a list of symbols,
-          the symbols refine the matching strategy: @scheme['case-insensitive] for
-          case-insensitive matching, and @scheme['delimited] to indicate that the
-          matched text's edges must coincide with forward and backward expression
-          nagivation.
+          first element of the list. When a nested list contains fourth and fifth
+          elements, they can supply replacements (when not @racket[#f]) for the default functions that
+          find a prefix and extract the subsequent name. See @secref["sec:define-popup"]
+          for information about the protocols for the finding and extraction procedures.
           
           The pair of strings alternative is deprecated. If it is used, 
           the pair @racket[(cons a-str b-str)] is the same as @racket[(list a-str b-str "δ")].

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -359,7 +359,7 @@ compatibility and new code should not use it.
 Similarly, if the fourth element from the list (the argument to @racket[#:number])
 is not present, then it is treated as @racket[#f].
 
-@section{Definition Popup-Menu Navigation}
+@section[#:tag "sec:define-popup"]{Definition Popup-Menu Navigation}
 
 @language-info-def[drracket:define-popup]{
  A popup menu in the DrRacket button bar jumps to definitions based on a
@@ -372,8 +372,25 @@ is not present, then it is treated as @racket[#f].
  @racketblock[
    (non-empty-listof (or/c (list/c string? string? string?)
                            (list/c string? string? string?
-                                   (listof (or/c 'case-sensitive 'delimited)))))
-  ]
+                                   (or/c #f
+                                         (-> (is-a/c text%)
+                                             string?
+                                             exact-integer?
+                                             (->* ((is-a/c text%)
+                                                   string?
+                                                   exact-integer?)
+                                                  (#:case-sensitive? any/c
+                                                   #:delimited? any/c)
+                                                  (or/c exact-integer? #f))
+                                             (or/c exact-integer? #f)))
+                                   (or/c #f
+                                         (-> (is-a/c text%)
+                                             exact-integer?
+                                             (-> (is-a/c text%)
+                                                 exact-integer?
+                                                 string?)
+                                             string?)))))
+ ]
 
  where the first string in each nested list is literal text to search
  for (outside of comments and literal strings), the second string is a
@@ -382,13 +399,32 @@ is not present, then it is treated as @racket[#f].
  used for the definition-popup button itself, while all labels are
  used for the user to select which categories are enabled.
 
- If a list of symbols is provided, it refines the matching strategy.
- By default, the literal text to find for a definition is found
- case-insensitively, but @racket['case-sensitive] enables a
- case-sensitive match. If @racket['delimited] is specified, then the
- text must match a token completely in the sense that
- expression-navigating forward or backward from one end will find the
- other end of the text.
+ When a nested list contains fourth and fifth elements, they can
+ supply replacements (when not @racket[#f]) for the default functions
+ that find a prefix and extract the subsequent name:
+
+ @itemlist[
+
+  @item{The prefix-finding function receives a text-editor object
+        for the content to search, the prefix string to find, a
+        position to start the search, and a default prefix-finding
+        function. The result is a position in the text editor for the
+        start of a found prefix, or @racket[#f] if the prefix is not
+        found.
+
+        The provided default finding function accepts two optional
+        keyword arguments: a true value for @racket[#:case-sensitive?]
+        requires case-insensitive matching, and a true value for
+        @racket[#:delimited?] indicates that the matched text's edges
+        must coincide with forward and backward expression
+        navigation.}
+
+ @item{The name-extracting function receives a text-editor object for
+       the content to extract, a position after a found prefix string,
+       and a default name-extracting function. The result must be a
+       string for the extracted defined name.}
+
+ ]
 
  Plugins can provide a default popup-menu configuration via
  @racket[drracket:language:register-capability] using @racket['drscheme:define-popup].


### PR DESCRIPTION
Predictably, having just a pair of symbol options is not configurable enough for the popup "define" menu. Remove the option symbols and instead support callback functions for the definition-finding and name-extracting tasks. Each callback receives the default implementation, in case it finds that helpful, and the former option symbols have turned into optional keyword arguments for the default definition-finding implementation.

Rhombus branch that uses the new protocol: https://github.com/mflatt/rhombus-prototype/tree/define-popup2, implementation in https://github.com/mflatt/rhombus-prototype/blob/define-popup2/rhombus/private/define-popup.rkt.