### PR TITLE
Document drracket:comment-delimiters

### DIFF
--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -67,7 +67,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.14")
+(define version "1.15")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -186,7 +186,7 @@ string used to end/close a comment, and @racket[_padding] goes
 after/before.
 
    Racket example: @racket['(region "#|" "|#" "  " " ")].
-   C++ example: @racket['(region "/*" "*/" " *" " ")].}
+   C++ example: @racket['(region "/*" " *" "*/" " ")].}
 
  ]
 

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -183,6 +183,12 @@ strings:
 
  The default value is @racket[(list (list ";;" "" " ") (list "#|" "|#" " "))].
 
+ When the list has multiple styles, some tools may present them for
+the user to pick one. Other tools may default to using the first style
+in the list (the user will configure a preference by others means).
+Therefore when a language supports multiple comment styles, it should
+list the most popular or preferred style first.
+
  @history[#:added "1.15"]
 }
 

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -167,21 +167,36 @@ The default value is @racket[(list #\" #\|)].
 
  When a language's @racket[_get-info] procedure responds to
 @racket['drracket:comment-delimiters], it is expected to return a list
-of comment styles. Each comment style is expressed as a list of three
-strings:
+of comment styles. Each comment style is expressed as one of:
 
  @itemlist[
 
-  @item{The characters used to start/open a comment.}
+  @item{@racket[(list 'line start padding)], where @racket[_start]
+   is a string used to start a comment that is teriminated by the
+   end of a line, and @racket[_padding] goes after that.
+   Lisp example: @racket['(line ";;" " ")].
+   C++ example: @racket['(line "//" " ")].}
 
-  @item{The characters used to end/close a comment. May be @litchar[""] to mean newline.}
+  @item{@racket[(list 'region start end padding)], where @racket[_start]
+   is a string used to start/open a comment, @racket[_end] is a string
+   used to end/close a comment, and @racket[_padding] goes after/before.
+   Racket example: @racket['(region "#|" "|#" " ")].
+   C++ example: @racket['(region "/*" "*/" " ")].}
 
-  @item{Padding to add after the start and before the close.}
  ]
 
- These values are used by comment and un-comment commands.
+ When not specified by a lang, the default value is
+ @racket[(list (list 'line ";;" " ") (list 'region "#|" "|#" " "))].
 
- The default value is @racket[(list (list ";;" "" " ") (list "#|" "|#" " "))].
+ An intended use for these values is for comment and un-comment
+commands, which may vary among tools. Some tools (un)comment entire
+lines, whereas others may handle portions of a line. Generally this is
+orthogonal to using a lang's line vs. region style: A tool can wrap
+entire lines using region comments, and a tool can insert line breaks
+to make it possible to use line comments. The point of
+@racket['drracket:comment-delimiters] is to enable a lang to tell a
+tool about its comment delimiters -- not to say exactly how
+the (un)comment commands could or should work, exactly.
 
  When the list has multiple styles, some tools may present them for
 the user to pick one. Other tools may default to using the first style

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -161,6 +161,31 @@ The default value is @racket[(list #\" #\|)].
  @history[#:added "1.10"]
 }
 
+@section{Comments}
+
+@language-info-def[drracket:comment-delimiters]{
+
+ When a language's @racket[_get-info] procedure responds to
+@racket['drracket:comment-delimiters], it is expected to return a list
+of comment styles. Each comment style is expressed as a list of three
+strings:
+
+ @itemlist[
+
+  @item{The characters used to start/open a comment.}
+
+  @item{The characters used to end/close a comment. May be @litchar[""] to mean newline.}
+
+  @item{Padding to add after the start and before the close.}
+ ]
+
+ These values are used by comment and un-comment commands.
+
+ The default value is @racket[(list (list ";;" "" " ") (list "#|" "|#" " "))].
+
+ @history[#:added "1.15"]
+}
+
 @section{Keystrokes}
 
 @language-info-def[drracket:keystrokes]{

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -183,6 +183,7 @@ plus @racket[_padding] starts a comment that is teriminated by the end
 of a line.
 
    Lisp example: @racket['(line ";;" " ")].
+
    C++ example: @racket['(line "//" " ")].}
 
  @item{@racket[(list 'region start continue end padding)], where:
@@ -198,6 +199,7 @@ multiple lines}
     @item{@racket[_padding] then @racket[_end] closes a comment}]
 
    Racket example: @racket['(region "#|" "|#" "  " " ")].
+
    C++ example: @racket['(region "/*" " *" "*/" " ")].}
 
  ]
@@ -206,23 +208,24 @@ multiple lines}
 Racket s-expression langs:
 
  @racketblock['((line ";;" " ")
-                (region "#|" "|#" "  " " "))].
+                (region "#|" "|#" "  " " "))]
 
- An intended use for these values is for comment and un-comment
-commands, which may vary among tools. Some tools (un)comment entire
-lines, whereas others may handle portions of a line. Generally this is
-orthogonal to using a lang's line vs. region style: A tool can wrap
-entire lines using region comments, and a tool can insert line breaks
-to make it possible to use line comments. The point of
+ An intended use for these values is by (un)comment commands, which
+vary among tools. Some tools (un)comment entire lines, whereas others
+may handle portions of a line. Generally this is orthogonal to using a
+lang's line vs. region style: A tool can wrap entire lines using
+region comments. A tool can insert line breaks to make it possible to
+use line comments on a portion of a line. The point of
 @racket['drracket:comment-delimiters] is to enable a lang to tell a
-tool about its comment delimiters -- not to say exactly how
+tool about its comment delimiters --- not to say exactly how
 the (un)comment commands could or should work, exactly.
 
- When the list has multiple styles, some tools may present them for
-the user to pick one. Other tools may default to using the first style
-in the list (the user will configure a preference by others means).
-Therefore when a language supports multiple comment styles, it should
-list the most popular or preferred style first.
+ When the list has multiple styles: Some tools may present the styles
+for the user to pick one. Other tools may default to using the first
+style in the list (allowing the user to configure another preference
+by other means). Therefore when a language supports multiple comment
+styles, it should @emph{list the most popular or preferred style
+first}.
 
  @history[#:added "1.15"]
 }

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -171,22 +171,27 @@ of comment styles. Each comment style is expressed as one of:
 
  @itemlist[
 
-  @item{@racket[(list 'line start padding)], where @racket[_start]
-   is a string used to start a comment that is teriminated by the
-   end of a line, and @racket[_padding] goes after that.
+  @item{@racket[(list 'line start padding)], where @racket[_start] is
+a string used to start a comment that is teriminated by the end of a
+line, and @racket[_padding] goes after that.
+
    Lisp example: @racket['(line ";;" " ")].
    C++ example: @racket['(line "//" " ")].}
 
-  @item{@racket[(list 'region start end padding)], where @racket[_start]
-   is a string used to start/open a comment, @racket[_end] is a string
-   used to end/close a comment, and @racket[_padding] goes after/before.
-   Racket example: @racket['(region "#|" "|#" " ")].
-   C++ example: @racket['(region "/*" "*/" " ")].}
+  @item{@racket[(list 'region start continue end padding)], where
+@racket[_start] is a string used to start/open a comment,
+@racket[_continue] is added to the beginning of each line except the
+first one when a comment spans multiple lines, @racket[_end] is a
+string used to end/close a comment, and @racket[_padding] goes
+after/before.
+
+   Racket example: @racket['(region "#|" "|#" "  " " ")].
+   C++ example: @racket['(region "/*" "*/" " *" " ")].}
 
  ]
 
- When not specified by a lang, the default value is
- @racket[(list (list 'line ";;" " ") (list 'region "#|" "|#" " "))].
+ When not specified by a lang, the default value is suitable for
+Racket s-expression langs: @racket['((line ";;" " ") (region "#|" "|#" " " " "))].
 
  An intended use for these values is for comment and un-comment
 commands, which may vary among tools. Some tools (un)comment entire

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -166,24 +166,36 @@ The default value is @racket[(list #\" #\|)].
 @language-info-def[drracket:comment-delimiters]{
 
  When a language's @racket[_get-info] procedure responds to
-@racket['drracket:comment-delimiters], it is expected to return a list
-of comment styles. Each comment style is expressed as one of:
+@racket['drracket:comment-delimiters], it is expected to return a
+value with this contract:
+
+ @racketblock[(listof
+               (or/c (list/c 'line string? string?)
+                     (list/c 'region string? string? string? string?)))]
+
+ The value is a list of comment styles. Each comment style is
+expressed as one of:
 
  @itemlist[
 
-  @item{@racket[(list 'line start padding)], where @racket[_start] is
-a string used to start a comment that is teriminated by the end of a
-line, and @racket[_padding] goes after that.
+  @item{@racket[(list 'line start padding)], where @racket[_start]
+plus @racket[_padding] starts a comment that is teriminated by the end
+of a line.
 
    Lisp example: @racket['(line ";;" " ")].
    C++ example: @racket['(line "//" " ")].}
 
-  @item{@racket[(list 'region start continue end padding)], where
-@racket[_start] is a string used to start/open a comment,
-@racket[_continue] is added to the beginning of each line except the
-first one when a comment spans multiple lines, @racket[_end] is a
-string used to end/close a comment, and @racket[_padding] goes
-after/before.
+ @item{@racket[(list 'region start continue end padding)], where:
+
+   @itemlist[
+
+    @item{@racket[_start] then @racket[_padding] opens a comment}
+
+    @item{@racket[_continue] then @racket[padding] is added to the
+beginning of each line except the first one when a comment spans
+multiple lines}
+
+    @item{@racket[_padding] then @racket[_end] closes a comment}]
 
    Racket example: @racket['(region "#|" "|#" "  " " ")].
    C++ example: @racket['(region "/*" " *" "*/" " ")].}
@@ -191,7 +203,10 @@ after/before.
  ]
 
  When not specified by a lang, the default value is suitable for
-Racket s-expression langs: @racket['((line ";;" " ") (region "#|" "|#" " " " "))].
+Racket s-expression langs:
+
+ @racketblock['((line ";;" " ")
+                (region "#|" "|#" "  " " "))].
 
  An intended use for these values is for comment and un-comment
 commands, which may vary among tools. Some tools (un)comment entire


### PR DESCRIPTION
The documentation portion of #634.

Note that this commit does /not/ add to the documented list of keys read by Dr Racket, because this commit does not add the behavior of Dr Dracket doing that and using the comment styles to drive its (un)comment commands.