### PR TITLE
Add Resyntax Autofixer workflow

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -1,0 +1,60 @@
+name: Resyntax Autofixer
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.6.0
+        # See https://github.com/actions/checkout/issues/118.
+        with:
+          fetch-depth: 0
+      - name: Install Racket
+        uses: Bogdanp/setup-racket@v1.9.1
+        with:
+          version: current
+          packages: resyntax
+          local_catalogs: $GITHUB_WORKSPACE
+          dest: '"${HOME}/racketdist-current-CS"'
+          sudo: never
+      - name: Register local packages
+        run: |
+          raco pkg install -i --auto --no-setup --skip-installed drracket-test drracket-tool-test
+          raco pkg update --auto --no-setup drracket drracket-test drracket-tool drracket-tool-test drracket-tool-lib drracket-tool-doc drracket-plugin-lib
+      - name: Install local packages
+        run: raco setup --pkgs drracket drracket-test drracket-tool drracket-tool-test drracket-tool-lib drracket-tool-doc drracket-plugin-lib
+      - name: Create a new branch
+        run: git checkout -b autofix-${{ github.run_number }}-${{ github.run_attempt }}
+      - name: Fix a random Racket file
+        run: xvfb-run racket -l- resyntax/cli fix --file "$(find . -name "*.rkt" -type f | shuf -n 1)" >> /tmp/resyntax-output.txt
+      - name: Create pull request
+        uses: actions/github-script@v6.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { readFile, writeFile } = require('fs/promises');
+            const resyntaxOutput = await readFile('/tmp/resyntax-output.txt');
+            const commitMessageBody = "```\n" + resyntaxOutput + "\n```";
+            const commitMessageTitle = "Automated Resyntax fixes";
+            const commitMessage = commitMessageTitle + "\n\n" + commitMessageBody;
+            await writeFile('/tmp/resyntax-commit-message.txt', commitMessage);
+            await exec.exec('git config user.name "GitHub Actions"');
+            await exec.exec('git config user.email "actions@github.com"');
+            await exec.exec('git commit --all --file=/tmp/resyntax-commit-message.txt');
+            await exec.exec('git push --set-upstream origin autofix-${{ github.run_number }}-${{ github.run_attempt }}');
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: commitMessageTitle,
+              head: "autofix-${{ github.run_number }}-${{ github.run_attempt }}",
+              base: "master",
+              body: commitMessageBody,
+              maintainer_can_modify: true,
+            });


### PR DESCRIPTION
This workflow causes Resyntax to pick a random file in the repository once a week to analyze. Resyntax will create a pull request with its suggested fixes if the file has issues. Fixes are generated on Sunday at midnight, I think (cron schedules are not my strong suit). The frequency can be scaled up or down if desired. The workflow can also be triggered manually from the GitHub Actions tab of the repository. Pull requests created by Resyntax won't be merged automatically; human approval is still required for any changes to be made to the repository.