### PR TITLE
Update menus.scrbl to cmd.exe

### DIFF
--- a/drracket/scribblings/drracket/menus.scrbl
+++ b/drracket/scribblings/drracket/menus.scrbl
@@ -533,7 +533,7 @@ brings the corresponding window to the front.
 
   On Windows, it changes the @tt{HKEY_CURRENT_USER\Environment\Path}
   registry key to add the location of the @filepath{bin} directory.
-  Once it finishes, newly created @tt{command.com} shells should have
+  Once it finishes, newly created Command shells (@tt{cmd.exe}) should have
   Racket in their path.
  }
   


### PR DESCRIPTION
replace command.com reference to `cmd.exe` using terminology from Microsoft documentation 
 https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands 
nb command.com was last present in Windows ME.