### PR TITLE
when receiving syntax objects from 'online-check-syntax logger,

### DIFF
--- a/drracket/drracket/private/syncheck/online-comp.rkt
+++ b/drracket/drracket/private/syncheck/online-comp.rkt
@@ -68,7 +68,8 @@
                       (get-init-dir path)))
     (parameterize ([current-annotations obj])
       (for ([stx (in-list stxes)])
-        (expanded-expression stx))
+        (when (equal? (syntax-source stx) the-source)
+          (expanded-expression stx)))
       (expansion-completed))
     (send obj get-trace)))
 

--- a/drracket/scribblings/tools/tools.scrbl
+++ b/drracket/scribblings/tools/tools.scrbl
@@ -844,6 +844,14 @@ The fourth argument to @racket[log-message] should be a list
 of syntax objects; these are processed as if they were the result
 of expansion. 
 
+The syntax objects whose @racket[syntax-source] field does
+not match the source of the file that is currently being
+expanded are ignored. That is, sometimes a macro may log a
+syntax object to be used by DrRacket in this fashion, but
+the macro may not be from the file that DrRacket's
+expanding, but one from one that is required by it; hence
+this check is in place to skip them.
+
 Note: the identifiers in these objects should be @racket[syntax-original?]
 or else they will be ignored by check syntax.
 


### PR DESCRIPTION
discard them unless their source matches the file that originally triggered the expansion

The goal here is to avoid showing annotations from files that are required (and expanded as part of that process).

related to racket/racket#4811