### PR TITLE
Surround "custom" with brackets in the language selection dropdown

### DIFF
--- a/drracket/drracket/private/unit.rkt
+++ b/drracket/drracket/private/unit.rkt
@@ -2262,7 +2262,7 @@
                                        (drracket:language-configuration:language-settings-settings
                                         settings))
                                  ""
-                                 (string-append " " (string-constant custom)))
+                                 (string-append " [" (string-constant custom) "]"))
                              " "))
         (update-teachpack-menu)
         (update-comment-out-menu-items)


### PR DESCRIPTION
Prior this PR, the language name in the language selection dropdown could read "Determine language from source custom" with some combinations of settings, which doesn't make sense. Either "custom" should be removed entirely,
or it should be parenthesized. Here, I use brackets to make it similar to the language name shown in the REPL pane.