### PR TITLE
Fix the Resyntax autofixer

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -32,7 +32,7 @@ jobs:
         run: raco setup --pkgs drracket drracket-test drracket-tool drracket-tool-test drracket-tool-lib drracket-tool-doc drracket-plugin-lib
       - name: Create a new branch
         run: git checkout -b autofix-${{ github.run_number }}-${{ github.run_attempt }}
-      - name: Fix a random Racket file
+      - name: Run Resyntax
         run: racket -l- resyntax/cli fix --directory . --max-fixes 10 >> /tmp/resyntax-output.txt
       - name: Create pull request
         uses: actions/github-script@v6.4.1

--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create a new branch
         run: git checkout -b autofix-${{ github.run_number }}-${{ github.run_attempt }}
       - name: Fix a random Racket file
-        run: xvfb-run racket -l- resyntax/cli fix --file "$(find . -name "*.rkt" -type f | shuf -n 1)" >> /tmp/resyntax-output.txt
+        run: racket -l- resyntax/cli fix --directory . --max-fixes 10 >> /tmp/resyntax-output.txt
       - name: Create pull request
         uses: actions/github-script@v6.4.1
         with:


### PR DESCRIPTION
The autofixer currently runs on a random file. However, if that file has nothing to fix, no changes are made so nothing happens. This pull request changes Resyntax to analyze the entire repository but uses the `--max-fixes` flag to limit the number of changes made to no more than ten fixes. Additionally, `xvfb-run` is removed since Resyntax no longer depends on the GUI framework.