### PR TITLE
Use new Resyntax autofixer commit message format

### DIFF
--- a/.github/workflows/resyntax-autofixer.yml
+++ b/.github/workflows/resyntax-autofixer.yml
@@ -33,15 +33,14 @@ jobs:
       - name: Create a new branch
         run: git checkout -b autofix-${{ github.run_number }}-${{ github.run_attempt }}
       - name: Run Resyntax
-        run: racket -l- resyntax/cli fix --directory . --max-fixes 10 >> /tmp/resyntax-output.txt
+        run: racket -l- resyntax/cli fix --directory . --max-fixes 10 --output-as-commit-message >> /tmp/resyntax-output.txt
       - name: Create pull request
         uses: actions/github-script@v6.4.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { readFile, writeFile } = require('fs/promises');
-            const resyntaxOutput = await readFile('/tmp/resyntax-output.txt');
-            const commitMessageBody = "```\n" + resyntaxOutput + "\n```";
+            const commitMessageBody = await readFile('/tmp/resyntax-output.txt', { encoding: 'utf8' });
             const commitMessageTitle = "Automated Resyntax fixes";
             const commitMessage = commitMessageTitle + "\n\n" + commitMessageBody;
             await writeFile('/tmp/resyntax-commit-message.txt', commitMessage);


### PR DESCRIPTION
I added the `--output-as-commit-message` flag to Resyntax which lets it output its summary as a Github markdown commit message. The results look like [this](https://github.com/jackfirth/racket-disposable/pull/123).