### PR TITLE
doc: describe Modes submenu of Edit menu

### DIFF
--- a/drracket/scribblings/drracket/menus.scrbl
+++ b/drracket/scribblings/drracket/menus.scrbl
@@ -216,6 +216,18 @@ case-sensitive and case-insensitive search.}
 @item{@defmenuitem{Complete Word} Completes the word at the
 insertion point, using the manuals as a source of completions.}
 
+@item{@defmenuitem{Modes}
+
+@itemize[
+
+  @item{@defmenuitem{Text Mode} Sets the editor mode to plain-text. }
+
+  @item{@defmenuitem{Racket Mode} Sets the editor mode to Racket. }
+
+  @item{@defmenuitem{Scheme Mode} Sets the editor mode to Scheme (Legacy). }
+
+]}
+
  @item{@defmenuitem{Preferences...} Opens the preferences dialog. See
   @secref["prefs-explanation"]. (On Mac OS, this menu item is in
   the Apple menu.)}  ]


### PR DESCRIPTION
This PR suggests adding a description for the Modes submenu of the Edit menu to `menus.scrbl`.

The immediate background is that someone on the drracket channel on the Discord server wanted to know if it was possible to edit ordinary text using DrRacket and the ensuing discussion revealed that `menus.scrbl` lacked a description for the Modes submenu.  Subsequently, spdegabrielle mentioned the idea of an appropriate PR.

On a side note, it looks like there is some mention of modes (including the "Modes" submenu) in [this section of the DrRacket Plugins docs](https://docs.racket-lang.org/tools/Editor_Modes.html) already.