### PR TITLE
add support for reverse-order cycling in `drracket:indentation` and `drracket:range-indentation`

### DIFF
--- a/drracket-core-lib/drracket/private/in-irl-namespace.rkt
+++ b/drracket-core-lib/drracket/private/in-irl-namespace.rkt
@@ -190,6 +190,12 @@
                exact-nonnegative-integer?
                exact-nonnegative-integer?
                (or/c #f (listof (list/c exact-nonnegative-integer? string?)))))]
+    [(drracket:range-indentation/reverse-choices)
+     (or/c #f
+           (-> read-only-text/c
+               exact-nonnegative-integer?
+               exact-nonnegative-integer?
+               (or/c #f (listof (list/c exact-nonnegative-integer? string?)))))]
     [(drracket:grouping-position)
      (or/c #f
            (-> read-only-text/c natural? natural? (or/c 'up 'down 'backward 'forward)

--- a/drracket-core-lib/drracket/private/insulated-read-language.rkt
+++ b/drracket-core-lib/drracket/private/insulated-read-language.rkt
@@ -31,6 +31,7 @@ Will not work with the definitions text surrogate interposition that
         'drracket:default-extension
         'drracket:indentation
         'drracket:range-indentation
+        'drracket:range-indentation/reverse-choices
         'drracket:grouping-position
         'drracket:keystrokes
         'drracket:show-big-defs/ints-labels
@@ -243,6 +244,13 @@ Will not work with the definitions text surrogate interposition that
              (λ () #f)
              (λ () (val txt pos)))))]
     [(drracket:range-indentation)
+     (and val
+          (λ (txt start-pos end-pos)
+            (call-in-irl-context/abort
+             an-irl
+             (λ () #f)
+             (λ () (val txt start-pos end-pos)))))]
+    [(drracket:range-indentation/reverse-choices)
      (and val
           (λ (txt start-pos end-pos)
             (call-in-irl-context/abort

--- a/drracket-core-lib/drracket/private/module-language-tools.rkt
+++ b/drracket-core-lib/drracket/private/module-language-tools.rkt
@@ -265,6 +265,13 @@
                      (range-indent (send defs get-range-indentation-function) start end))
           (super tabify-selection start end)))
 
+      (define/override (tabify-selection/reverse-choices [start (get-start-position)]
+                                                         [end (get-end-position)])
+        (define defs (get-definitions-text))
+        (unless (and (send defs get-in-module-language?)
+                     (range-indent (send defs get-range-indentation/reverse-choices-function) start end))
+          (super tabify-selection/reverse-choices start end)))
+
       (define/override (tabify-all)
         (define defs (get-definitions-text))
         (unless (and (send defs get-in-module-language?)
@@ -503,6 +510,9 @@
         (set! range-indentation-function
               (or (call-read-language the-irl 'drracket:range-indentation #f)
                   (λ (x y z) #f)))
+        (set! range-indentation/reverse-choices-function
+              (or (call-read-language the-irl 'drracket:range-indentation/reverse-choices #f)
+                  (λ (x y z) #f)))
         (set! grouping-position
               (or (call-read-language the-irl 'drracket:grouping-position #f)
                   default-grouping-position))
@@ -559,6 +569,7 @@
         (set! default-extension "")
         (set! indentation-function (λ (x y) #f))
         (set! range-indentation-function (λ (x y z) #f))
+        (set! range-indentation/reverse-choices-function (λ (x y z) #f))
         (set! grouping-position default-grouping-position)
         (when lang-keymap
           (send (get-keymap) remove-chained-keymap lang-keymap)
@@ -674,6 +685,8 @@
       (define/public (get-indentation-function) indentation-function)
       (define range-indentation-function (λ (x y z) #f))
       (define/public (get-range-indentation-function) range-indentation-function)
+      (define range-indentation/reverse-choices-function (λ (x y z) #f))
+      (define/public (get-range-indentation/reverse-choices-function) range-indentation/reverse-choices-function)
       (define grouping-position default-grouping-position)
       (define lang-keymap #f)
       (define/public (with-language-specific-default-extensions-and-filters t)
@@ -699,6 +712,12 @@
         (unless (and in-module-language?
                      (range-indent range-indentation-function start end))
           (super tabify-selection start end)))
+
+      (define/override (tabify-selection/reverse-choices [start (get-start-position)]
+                                                         [end (get-end-position)])
+        (unless (and in-module-language?
+                     (range-indent range-indentation/reverse-choices-function start end))
+          (super tabify-selection/reverse-choices start end)))
 
       (define/override (tabify-all)
         (unless (and in-module-language?

--- a/drracket-core-lib/info.rkt
+++ b/drracket-core-lib/info.rkt
@@ -42,7 +42,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.0")
+(define version "1.16")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/drracket-core/info.rkt
+++ b/drracket-core/info.rkt
@@ -36,7 +36,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.15")
+(define version "1.16")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/drracket-core/info.rkt
+++ b/drracket-core/info.rkt
@@ -36,7 +36,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.0")
+(define version "1.15")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/drracket-core/scribblings/tools/lang-tools.scrbl
+++ b/drracket-core/scribblings/tools/lang-tools.scrbl
@@ -153,6 +153,19 @@ only @racket['drracket:indentation] is used.
  @history[#:added "1.10"]
 }
 
+@language-info-def[drracket:range-indentation/reverse-choices]{
+
+When a language's @racket[_get-info] procedure responds to
+@racket['drracket:range-indentation/reverse-choices], it is expected
+to return a procedure like one for @racket['drracket:range-indentation],
+but if there are multiple indentation choices to cycle through, then
+cycling should go through the choices in reverse order. When this function
+returns @racket[#f], then a non-reversed indentation is tried.
+
+ @history[#:added "1.16"]
+}
+
+
 @language-info-def[drracket:paren-matches]{
 
 When a language's @racket[_get-info] procedure responds to

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -40,7 +40,7 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.15")
+(define version "1.16")
 
 (define license
   '(Apache-2.0 OR MIT))


### PR DESCRIPTION
For a language that can offer indentation alternatives, such as Rhombus, allow a reserve-order request via a new argument to a function provided for `drracket:indentation` and `drracket:range-indentation`.

The new argument is a list of options, just in case additional options are needed in the future. Currently, the list is always `'()` or `'(reverse)`.