### PR TITLE
Don't use racket/private/namespace (easy)

### DIFF
--- a/drracket/gui-debugger/load-sandbox.rkt
+++ b/drracket/gui-debugger/load-sandbox.rkt
@@ -2,7 +2,7 @@
   
   (require syntax/moddep
            mzlib/class
-           racket/private/namespace
+           (only racket/base make-base-namespace)
            mred)  
   
   (provide eval/annotations


### PR DESCRIPTION
Summary:

Instead of requiring `racket/private/namespace` for make-base-namespace, just grab it with `(only racket/base make-base-namespace)` instead.

Test Plan:

With the file open in DrRacket, a single `make-base-namespace` call was the only shown bound occurrence of the require.