### PR TITLE
reveal errortrace annotations via `errortrace-continuation-mark-set->context`

### DIFF
--- a/drracket-core-lib/drracket/private/eval-helpers-and-pref-init.rkt
+++ b/drracket-core-lib/drracket/private/eval-helpers-and-pref-init.rkt
@@ -10,9 +10,11 @@
          pkg/lib
          framework/preferences
          errortrace/stacktrace
+         errortrace/marks-to-context
          "drracket-errortrace-key.rkt"
          (prefix-in *** '#%foreign) ;; just to make sure it is here
-         "compiled-dir.rkt")
+         "compiled-dir.rkt"
+         (submod "stack-checkpoint.rkt" item->srcloc))
 
 (provide set-basic-parameters/no-gui
          set-module-language-parameters
@@ -165,6 +167,15 @@
                                        (use-compiled-file-paths))])
                  (orig path mod-name))
                (orig path mod-name))))))
+
+    (errortrace-continuation-mark-set->context
+     (let ([drracket-errortrace-lib-continuation-mark-set->context
+            (λ (cms)
+              (map
+               errortrace-stack-item->srcloc
+               (continuation-mark-set->list cms drracket-errortrace-key)))])
+       drracket-errortrace-lib-continuation-mark-set->context))
+
     ;; Install the compilation manager:
     (current-parallel-lock-shutdown-evt (make-custodian-box (current-custodian) #t))
     (parallel-lock-client module-language-parallel-lock-client)

--- a/drracket-core-lib/drracket/private/eval.rkt
+++ b/drracket-core-lib/drracket/private/eval.rkt
@@ -198,6 +198,7 @@
             '(lib "simple-tree-text-markup/data.rkt")
             ; srclocs-special<%>
             '(lib "simple-tree-text-markup/port.rkt")
+            '(lib "errortrace/marks-to-context.rkt")
             ;; preserve the invariant that:
             ;;   if a module is shared, so 
             ;;   are all of its submodules

--- a/drracket-core-lib/drracket/private/stack-checkpoint.rkt
+++ b/drracket-core-lib/drracket/private/stack-checkpoint.rkt
@@ -36,6 +36,17 @@
          errortrace-stack-item->srcloc
          copy-viewable-stack)
 
+(module item->srcloc racket/base
+  (provide errortrace-stack-item->srcloc)
+  
+  (define (errortrace-stack-item->srcloc x)
+    (make-srcloc (vector-ref x 0)
+                 (vector-ref x 1)
+                 (vector-ref x 2)
+                 (vector-ref x 3)
+                 (vector-ref x 4))))
+(require (submod "." item->srcloc))
+
 (provide
  (contract-out
   [cut-stack-at-checkpoint (-> continuation-mark-set? (listof srcloc?))]
@@ -175,13 +186,6 @@
                         errortrace-stack-item->srcloc
                         interesting-editors
                         a-viewable-stack))
-
-(define (errortrace-stack-item->srcloc x)
-  (make-srcloc (vector-ref x 0)
-               (vector-ref x 1)
-               (vector-ref x 2)
-               (vector-ref x 3)
-               (vector-ref x 4)))
 
 (define (cms->builtin-viewable-stack cms interesting-editors
                                      #:share-cache [a-viewable-stack #f])

--- a/drracket-core-lib/info.rkt
+++ b/drracket-core-lib/info.rkt
@@ -11,7 +11,7 @@
                ["drracket-plugin-lib" #:version "1.1"]
                "drracket-tool-lib"
                "drracket-tool-text-lib"
-               ["errortrace-lib" #:version "1.5"]
+               ["errortrace-lib" #:version "1.6"]
                ["gui-lib" #:version "1.76"]
                "gui-pkg-manager-lib"
                ["icons" #:version "1.2"]


### PR DESCRIPTION
Depends on https://github.com/racket/errortrace/pull/38 and is intended to help with https://github.com/racket/htdp/issues/253